### PR TITLE
 Support for Axzon Magnus S2 tags and moisture sensing

### DIFF
--- a/CS108iOSClient.xcodeproj/xcuserdata/TurtleMac01.xcuserdatad/xcschemes/CS108iOSClient.xcscheme
+++ b/CS108iOSClient.xcodeproj/xcuserdata/TurtleMac01.xcuserdatad/xcschemes/CS108iOSClient.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CS108iOSClient/CSLReader/CSLBleReader+AccessControl.h
+++ b/CS108iOSClient/CSLReader/CSLBleReader+AccessControl.h
@@ -66,6 +66,26 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL) sendHostCommandLock;
 
 /**
+ Clear all tag select criteria (8 in total)
+ @return TRUE if the operation is successful
+ */
+- (BOOL) clearAllTagSelect;
+/**
+ EPC match configuration
+ @param match_enable 1 = EPC matching enabled, 0 = EPC matching disabled
+ @param epc_notEpc 0 = match on EPC, 1 = match on ~EPC
+ @param match_length Length of EPC match data in bits
+ @param match_offset Offset in bits of where to start the compare in the EPC read from the tag
+ @return TRUE if the operation is successful
+ */
+- (BOOL) setEpcMatchConfiguration:(BOOL)match_enable matchOn:(BOOL)epc_notEpc matchLength:(UInt16)match_length matchOffset:(UInt16)match_offset;
+/**
+ Delay time between inventory cycle.
+ @param cycle_delay Time delay in-between each inventory cycle in ms (use to reduce tag rate).  The values should be between 0 to 2000.  0 means fastest tag rate.
+ @return TRUE if the operation is successful
+ */
+- (BOOL) setInventoryCycleDelay:(UInt32) cycle_delay;
+/**
  Select tag before tag access (read/write) operation
  @param maskbank Mask bank to be used for tag selection
  @param ptr Pointer to the start of the memory address, to be expressed by bits

--- a/CS108iOSClient/CSLReader/CSLBleReader.m
+++ b/CS108iOSClient/CSLReader/CSLBleReader.m
@@ -1434,7 +1434,7 @@
     //Select which set of algorithm parameter registers to access (INV_SEL) reg_addr = 0x0902
     //Byte Inv_algo=0x03, match_rep=0, tag_sel=0, disable_inv=0, tag_read=0, crc_err_read=1, QT_mode=0, tag_delay=0, inv_mode=1;  //inventory algorithm #3, enable crc error read, compact mode inventory
     NSLog(@"----------------------------------------------------------------------");
-    NSLog(@"Set inventory configurations (INV_CFG) addr:0x0902...");
+    NSLog(@"Set inventory configurations (INV_CFG) addr:0x0901...");
     NSLog(@"----------------------------------------------------------------------");
     
     unsigned char INV_CFG[] = {0x80, 0x02, 0x70, 0x01, 0x01, 0x09, (inventoryAlgorithm & 0x3F) + ((match_rep & 0x03) << 6), ((match_rep & 0xFC) >> 2) + ((tag_sel & 0x01) << 6) + ((disable_inventory & 0x01) << 7), (tag_read & 0x03) + ((crc_err_read & 0x01) << 2) + ((QT_mode & 0x01) << 3) + ((tag_delay & 0x0F) << 4), ((tag_delay & 0x30) >> 4) + ((inv_mode & 0x01) << 2)};

--- a/CS108iOSClient/CSLRfidDemoApp.storyboard
+++ b/CS108iOSClient/CSLRfidDemoApp.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="uy9-1K-dab">
-    <device id="retina4_0" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="uy9-1K-dab">
+    <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,7 +26,7 @@
             <objects>
                 <navigationController id="uy9-1K-dab" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="Cd5-iw-shF">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -42,27 +42,27 @@
             <objects>
                 <viewController storyboardIdentifier="ID_HomeVc" id="fVS-GJ-XIB" userLabel="Home" customClass="CSLHomeVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="9GR-iC-bpe">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="504"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" heightSizable="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Uid-YZ-2hb" userLabel="Main Menu">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="504"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="8Rs-Ug-MPv" userLabel="Row 1">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="126"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="151"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IUG-8G-nxk" userLabel="Temperature ">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="126"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="187.5" height="151"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8sE-5s-Nt0" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="8" width="152" height="110"/>
+                                                        <rect key="frame" x="8" y="8" width="179.5" height="135"/>
                                                         <subviews>
                                                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="4T3-Qs-EDw">
                                                                 <rect key="frame" x="58" y="37" width="37" height="37"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             </activityIndicatorView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Temperature" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="huf-M0-haL">
-                                                                <rect key="frame" x="27" y="81.5" width="98.5" height="20.5"/>
+                                                                <rect key="frame" x="40.5" y="106.5" width="98.5" height="20.5"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="huf-M0-haL" secondAttribute="height" multiplier="97:20" id="QR7-iW-mzg"/>
                                                                 </constraints>
@@ -71,7 +71,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v4b-VQ-L5K" userLabel="Read Temperature">
-                                                                <rect key="frame" x="41" y="11" width="70" height="70"/>
+                                                                <rect key="frame" x="42.5" y="11" width="94.5" height="95"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="v4b-VQ-L5K" secondAttribute="height" multiplier="1:1" id="tO8-km-qMT"/>
                                                                 </constraints>
@@ -100,19 +100,19 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xqt-A2-xFg" userLabel="Inventory">
-                                                <rect key="frame" x="160" y="0.0" width="160" height="126"/>
+                                                <rect key="frame" x="187.5" y="0.0" width="187.5" height="151"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="buP-Me-Ccc" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="8" width="144" height="110"/>
+                                                        <rect key="frame" x="8" y="8" width="171.5" height="135"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Inventory" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y9u-vK-5Ya" userLabel="Inventory">
-                                                                <rect key="frame" x="35" y="81.5" width="74.5" height="20.5"/>
+                                                                <rect key="frame" x="48.5" y="106.5" width="74.5" height="20.5"/>
                                                                 <fontDescription key="fontDescription" name="Lato-Bold" family="Lato" pointSize="17"/>
                                                                 <color key="textColor" red="0.0" green="0.25490196078431371" blue="0.52156862745098043" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OVN-EW-9iv">
-                                                                <rect key="frame" x="34.5" y="8" width="75" height="75"/>
+                                                                <rect key="frame" x="36" y="8" width="99.5" height="100"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="OVN-EW-9iv" secondAttribute="height" multiplier="1:1" id="ZjB-4f-V1i"/>
                                                                 </constraints>
@@ -155,16 +155,16 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="M3H-IU-kk8" userLabel="Row 2">
-                                        <rect key="frame" x="0.0" y="126" width="320" height="126"/>
+                                        <rect key="frame" x="0.0" y="151" width="375" height="150.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IIE-Iu-Ela" userLabel="Find your Item">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="126"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="187.5" height="150.5"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fIP-MN-c4U" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="0.0" width="152" height="118"/>
+                                                        <rect key="frame" x="8" y="0.0" width="179.5" height="142.5"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JoP-Gb-s9g">
-                                                                <rect key="frame" x="38.5" y="11" width="75" height="75"/>
+                                                                <rect key="frame" x="40" y="11" width="99.5" height="99.5"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="JoP-Gb-s9g" secondAttribute="height" multiplier="1:1" id="YXe-Ol-N5H"/>
                                                                 </constraints>
@@ -174,7 +174,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Find your Item" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wSd-pG-TcJ">
-                                                                <rect key="frame" x="8" y="91" width="136" height="22"/>
+                                                                <rect key="frame" x="8" y="115.5" width="163.5" height="22"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="22" id="FRk-A4-95t"/>
                                                                 </constraints>
@@ -203,13 +203,13 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Hy-6j-UxT" userLabel="Access Control ">
-                                                <rect key="frame" x="160" y="0.0" width="160" height="126"/>
+                                                <rect key="frame" x="187.5" y="0.0" width="187.5" height="150.5"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kww-pT-eW1" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="0.0" width="144" height="118"/>
+                                                        <rect key="frame" x="8" y="0.0" width="171.5" height="142.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Access Control" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y4v-5P-qF0">
-                                                                <rect key="frame" x="8" y="91" width="128" height="21"/>
+                                                                <rect key="frame" x="8" y="115.5" width="155.5" height="21"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="21" id="0Rn-eW-6fZ"/>
                                                                 </constraints>
@@ -218,7 +218,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nXY-Q5-Bo1">
-                                                                <rect key="frame" x="37" y="13" width="70" height="70"/>
+                                                                <rect key="frame" x="38.5" y="13" width="94.5" height="94.5"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="nXY-Q5-Bo1" secondAttribute="height" multiplier="1:1" id="bfY-T3-XUY"/>
                                                                 </constraints>
@@ -250,16 +250,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="SDR-o3-dfe" userLabel="Row 3">
-                                        <rect key="frame" x="0.0" y="252" width="320" height="126"/>
+                                        <rect key="frame" x="0.0" y="301.5" width="375" height="151"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="upm-cG-C2d" userLabel="More Functions">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="126"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="187.5" height="151"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LVX-Jg-3ja" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="0.0" width="152" height="126"/>
+                                                        <rect key="frame" x="8" y="0.0" width="179.5" height="151"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="We5-DV-fsO">
-                                                                <rect key="frame" x="38.5" y="17" width="75" height="75"/>
+                                                                <rect key="frame" x="40" y="17" width="99.5" height="100"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="We5-DV-fsO" secondAttribute="height" multiplier="1:1" id="eXT-yh-ixA"/>
                                                                 </constraints>
@@ -269,7 +269,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="More Functions" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ga5-Ib-nlw" userLabel="More Functions">
-                                                                <rect key="frame" x="-1" y="98" width="154" height="22"/>
+                                                                <rect key="frame" x="-1" y="123" width="181.5" height="22"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="22" id="QtX-TJ-ESg"/>
                                                                 </constraints>
@@ -298,13 +298,13 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hfh-qg-BNM" userLabel="Settings">
-                                                <rect key="frame" x="160" y="0.0" width="160" height="126"/>
+                                                <rect key="frame" x="187.5" y="0.0" width="187.5" height="151"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="87g-LZ-oSU" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="0.0" width="144" height="126"/>
+                                                        <rect key="frame" x="8" y="0.0" width="171.5" height="151"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A7f-aE-j1K">
-                                                                <rect key="frame" x="34.5" y="16" width="75" height="75"/>
+                                                                <rect key="frame" x="36" y="16" width="99.5" height="99.5"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="A7f-aE-j1K" secondAttribute="height" multiplier="1:1" id="wOA-Jm-foP"/>
                                                                 </constraints>
@@ -315,7 +315,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Settings" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Ka-i3-Zp4">
-                                                                <rect key="frame" x="21" y="98.5" width="102" height="21"/>
+                                                                <rect key="frame" x="21" y="123" width="129.5" height="21"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="21" id="GjN-8L-oAF"/>
                                                                 </constraints>
@@ -346,16 +346,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uCH-An-loC" userLabel="Row 4">
-                                        <rect key="frame" x="0.0" y="378" width="320" height="126"/>
+                                        <rect key="frame" x="0.0" y="452.5" width="375" height="150.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fFT-h6-vjf">
-                                                <rect key="frame" x="0.0" y="0.0" width="320" height="126"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="150.5"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xYS-NA-EWo" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="8" width="304" height="110"/>
+                                                        <rect key="frame" x="8" y="8" width="359" height="134.5"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5bM-Yv-yrX">
-                                                                <rect key="frame" x="124.5" y="8" width="55.5" height="55.5"/>
+                                                                <rect key="frame" x="139.5" y="8" width="80" height="80"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="5bM-Yv-yrX" secondAttribute="height" multiplier="1:1" id="fxr-Xw-P89"/>
                                                                 </constraints>
@@ -365,7 +365,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Press to Connect" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M7Q-CB-AQL" userLabel="Connect">
-                                                                <rect key="frame" x="8" y="67.5" width="288" height="21"/>
+                                                                <rect key="frame" x="8" y="92" width="343" height="21"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="21" id="oua-9R-hWA"/>
                                                                 </constraints>
@@ -374,7 +374,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B9i-o6-WpN">
-                                                                <rect key="frame" x="153" y="89.5" width="0.0" height="0.0"/>
+                                                                <rect key="frame" x="180.5" y="114" width="0.0" height="0.0"/>
                                                                 <fontDescription key="fontDescription" name="Lato-Bold" family="Lato" pointSize="17"/>
                                                                 <color key="textColor" red="0.0" green="0.25490196078431371" blue="0.52156862745098043" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -454,14 +454,14 @@
             <objects>
                 <viewController storyboardIdentifier="ID_TagSearchVC" id="qel-VM-Uw9" userLabel="CslRfid findYourItemVC" customClass="CSLTagSearchVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="kuj-AL-YiZ">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="519"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="TXi-8X-gJt">
-                                <rect key="frame" x="5" y="40" width="310" height="475"/>
+                                <rect key="frame" x="5" y="40" width="365" height="574"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="RWl-16-bGc" userLabel="EPC Elements">
-                                        <rect key="frame" x="0.0" y="0.0" width="310" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="365" height="20.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="EPC" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MoO-FG-klp" userLabel="EPC">
                                                 <rect key="frame" x="0.0" y="0.0" width="32" height="20.5"/>
@@ -470,7 +470,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UDx-ql-S6S" userLabel="EPC Text">
-                                                <rect key="frame" x="37" y="0.0" width="273" height="20.5"/>
+                                                <rect key="frame" x="37" y="0.0" width="328" height="20.5"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -478,10 +478,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Zk-bw-WQ1" userLabel="Gauge Elements">
-                                        <rect key="frame" x="0.0" y="20.5" width="310" height="424.5"/>
+                                        <rect key="frame" x="0.0" y="20.5" width="365" height="523.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p5r-vv-1BP" customClass="LMGaugeView">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="424.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="523.5"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="numOfDivisions">
@@ -499,7 +499,7 @@
                                         </subviews>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XaP-TP-hj6" userLabel="Start ">
-                                        <rect key="frame" x="0.0" y="445" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="544" width="365" height="30"/>
                                         <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="vjo-Z9-5Dm" userLabel="height = 40"/>
@@ -540,11 +540,11 @@
             <objects>
                 <tableViewController storyboardIdentifier="ID_DeviceTV" id="yuX-ds-zWc" customClass="CSLDeviceTV" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="4wQ-5s-Yjz">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <activityIndicatorView key="tableFooterView" hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" id="SKt-Ko-cfU">
-                            <rect key="frame" x="0.0" y="0.0" width="320" height="20"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="20"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
                         </activityIndicatorView>
                         <connections>
@@ -566,23 +566,23 @@
             <objects>
                 <viewController storyboardIdentifier="ID_SettingsVC" id="D4r-Hh-STj" userLabel="CslRfid SettingsVC" customClass="CSLSettingsVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="QK7-MR-2Qr">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="9" translatesAutoresizingMaskIntoConstraints="NO" id="2ci-gg-415">
-                                <rect key="frame" x="5" y="40" width="310" height="350"/>
+                                <rect key="frame" x="5" y="40" width="365" height="344"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="60" translatesAutoresizingMaskIntoConstraints="NO" id="Y6L-Xl-CtA" userLabel="Power">
-                                        <rect key="frame" x="0.0" y="0.0" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Power (dBm)" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lFJ-9N-x0b">
-                                                <rect key="frame" x="0.0" y="0.0" width="100" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="155" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="300" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="d5y-O8-4jJ" userLabel="Power (dBm) Text">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="30"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="XdA-KM-eEv"/>
                                                 </constraints>
@@ -596,16 +596,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RaG-m4-d2X" userLabel="Tag Population">
-                                        <rect key="frame" x="0.0" y="39" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="39" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tag Population (1-8192)" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oME-0J-j5l">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="215" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="30" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="4ea-G0-hCn" userLabel="Tag population Text">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="30"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="8iy-VV-giC"/>
                                                 </constraints>
@@ -619,7 +619,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8YL-ur-pGS" userLabel="Q Override">
-                                        <rect key="frame" x="0.0" y="78" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="78" width="365" height="31"/>
                                         <subviews>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="qiV-xz-dTi" userLabel="Q Override Switch">
                                                 <rect key="frame" x="0.0" y="0.0" width="52" height="31"/>
@@ -632,13 +632,13 @@
                                                 </connections>
                                             </switch>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Q Override (0-15)" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="IaC-QB-c5v">
-                                                <rect key="frame" x="50" y="0.0" width="110" height="31"/>
+                                                <rect key="frame" x="50" y="0.0" width="165" height="31"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="6" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="67m-KF-yjA" userLabel="Q Override Text">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="31"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="31"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="dpf-Rj-fqg"/>
                                                 </constraints>
@@ -652,16 +652,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0ye-zn-KoV" userLabel="Target">
-                                        <rect key="frame" x="0.0" y="118" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="118" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Target" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="cau-l6-xJ0">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8rE-fh-szq">
-                                                <rect key="frame" x="110" y="0.0" width="200" height="30"/>
+                                                <rect key="frame" x="165" y="0.0" width="200" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="pMG-Vr-s6v"/>
                                                 </constraints>
@@ -676,16 +676,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OPP-nY-vgO" userLabel="Session">
-                                        <rect key="frame" x="0.0" y="157" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="157" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Session" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2KW-y1-XQn">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Al8-UR-NAN">
-                                                <rect key="frame" x="110" y="0.0" width="200" height="30"/>
+                                                <rect key="frame" x="165" y="0.0" width="200" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="D9K-hg-lRd"/>
                                                 </constraints>
@@ -700,16 +700,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6UT-KY-nK9" userLabel="Query Algorithm">
-                                        <rect key="frame" x="0.0" y="196" width="310" height="36"/>
+                                        <rect key="frame" x="0.0" y="196" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Query Algorithm" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="I7C-tC-ePG">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="36"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iOF-yf-zif">
-                                                <rect key="frame" x="110" y="0.0" width="200" height="36"/>
+                                                <rect key="frame" x="165" y="0.0" width="200" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="aVT-0C-fur"/>
                                                 </constraints>
@@ -724,16 +724,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X25-FJ-VkZ" userLabel="Reader Mode">
-                                        <rect key="frame" x="0.0" y="241" width="310" height="27"/>
+                                        <rect key="frame" x="0.0" y="235" width="365" height="27"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reader Mode  " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Vmm-Z4-z30">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="27"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="27"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rYb-uQ-pYe">
-                                                <rect key="frame" x="110" y="0.0" width="200" height="27"/>
+                                                <rect key="frame" x="165" y="0.0" width="200" height="27"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="42d-Dk-y0m" userLabel="width = 300"/>
                                                 </constraints>
@@ -748,16 +748,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t2Y-k8-mzO">
-                                        <rect key="frame" x="0.0" y="277" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="271" width="365" height="31"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Sound  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="1KI-Qa-crc">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="31"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="31"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EWm-49-5td">
-                                                <rect key="frame" x="110" y="0.0" width="202" height="31"/>
+                                                <rect key="frame" x="165" y="0.0" width="202" height="31"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="MhX-Sk-7Zr"/>
                                                 </constraints>
@@ -766,10 +766,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nur-3L-wde">
-                                        <rect key="frame" x="0.0" y="317" width="310" height="33"/>
+                                        <rect key="frame" x="0.0" y="311" width="365" height="33"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GrJ-gh-Nj9">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="33"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="33"/>
                                                 <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                                 <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -814,17 +814,17 @@
             <objects>
                 <viewController storyboardIdentifier="ID_MQTTSettingsVC" id="oHS-yD-YtL" customClass="CSLMQTTClientSettings" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="M3F-lJ-YMn">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="bWT-FV-gqc" userLabel="MQTT Settings">
-                                <rect key="frame" x="5" y="40" width="310" height="412"/>
+                                <rect key="frame" x="5" y="40" width="365" height="412"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aF0-2O-ODk" userLabel="MQTT Title">
-                                        <rect key="frame" x="0.0" y="0.0" width="310" height="18"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="365" height="18"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MQTT Broker Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5eB-Qc-SSG">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="18"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="18"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -832,31 +832,31 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dol-NW-EAo" userLabel="Enable MQTT">
-                                        <rect key="frame" x="0.0" y="28" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="28" width="365" height="31"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable MQTT Connection" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wqu-XC-A0A" userLabel="Enable MQTT">
-                                                <rect key="frame" x="0.0" y="0.0" width="261" height="31"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="316" height="31"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Mtd-oz-aTW" userLabel="Enable MQTT Switch">
-                                                <rect key="frame" x="261" y="0.0" width="51" height="31"/>
+                                                <rect key="frame" x="316" y="0.0" width="51" height="31"/>
                                                 <color key="onTintColor" red="0.0" green="0.68235294117647061" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             </switch>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="utC-Ub-Kft" userLabel="Broker Address">
-                                        <rect key="frame" x="0.0" y="69" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="69" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Broker Addr" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WlK-pd-HwL">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NsP-3x-qLX">
-                                                <rect key="frame" x="110" y="0.0" width="200" height="30"/>
+                                                <rect key="frame" x="165" y="0.0" width="200" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="bG2-2G-Kje"/>
                                                 </constraints>
@@ -867,16 +867,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gCe-gg-EMm" userLabel="Broker Port">
-                                        <rect key="frame" x="0.0" y="109" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="109" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Broker Port  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ef4-1v-UQU">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vN2-bT-y4S">
-                                                <rect key="frame" x="110" y="0.0" width="200" height="30"/>
+                                                <rect key="frame" x="165" y="0.0" width="200" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="sYk-Ey-aTh"/>
                                                 </constraints>
@@ -887,16 +887,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="npO-u7-QPZ" userLabel="Client ID">
-                                        <rect key="frame" x="0.0" y="149" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="149" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Client ID  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NmI-i7-m7G">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KqS-iB-BaH">
-                                                <rect key="frame" x="110" y="0.0" width="200" height="30"/>
+                                                <rect key="frame" x="165" y="0.0" width="200" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="kmr-1w-Hwa"/>
                                                 </constraints>
@@ -907,16 +907,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W4V-XM-Qtk" userLabel="User Name">
-                                        <rect key="frame" x="0.0" y="189" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="189" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User Name  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rJk-GE-HrN">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cEU-tU-UCB">
-                                                <rect key="frame" x="110" y="0.0" width="200" height="30"/>
+                                                <rect key="frame" x="165" y="0.0" width="200" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="7xF-eO-XF7"/>
                                                 </constraints>
@@ -927,16 +927,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oJt-t2-qKY" userLabel="Password">
-                                        <rect key="frame" x="0.0" y="229" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="229" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Password  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oZr-h2-5RR">
-                                                <rect key="frame" x="0.0" y="0.0" width="110" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="165" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zdB-fk-DQu">
-                                                <rect key="frame" x="110" y="0.0" width="200" height="30"/>
+                                                <rect key="frame" x="165" y="0.0" width="200" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="1ru-es-LoC"/>
                                                 </constraints>
@@ -947,25 +947,25 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b8Q-jX-m3H" userLabel="Encryption">
-                                        <rect key="frame" x="0.0" y="269" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="269" width="365" height="31"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable TLSv1.2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bxI-bw-JGm">
-                                                <rect key="frame" x="0.0" y="0.0" width="261" height="31"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="316" height="31"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PqF-nJ-GuF">
-                                                <rect key="frame" x="261" y="0.0" width="51" height="31"/>
+                                                <rect key="frame" x="316" y="0.0" width="51" height="31"/>
                                                 <color key="onTintColor" red="0.0" green="0.68235294117647061" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             </switch>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S6N-fZ-YwF" userLabel="Encryption Info">
-                                        <rect key="frame" x="0.0" y="310" width="310" height="18"/>
+                                        <rect key="frame" x="0.0" y="310" width="365" height="18"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" (CA Signed Server Certificate)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fO2-2i-IeR">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="18"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="18"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -973,7 +973,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xua-wf-w09" userLabel="LWT">
-                                        <rect key="frame" x="0.0" y="338" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="338" width="365" height="31"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="QoS  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="89i-mw-dsM">
                                                 <rect key="frame" x="0.0" y="0.0" width="100" height="31"/>
@@ -985,13 +985,13 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="1" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xjq-j0-Qlf">
-                                                <rect key="frame" x="100" y="0.0" width="61" height="31"/>
+                                                <rect key="frame" x="100" y="0.0" width="116" height="31"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Retained" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jmZ-I5-i7u">
-                                                <rect key="frame" x="161" y="0.0" width="100" height="31"/>
+                                                <rect key="frame" x="216" y="0.0" width="100" height="31"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="100" id="0cN-OZ-CF1"/>
                                                 </constraints>
@@ -1000,16 +1000,16 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Kna-UI-TUf">
-                                                <rect key="frame" x="261" y="0.0" width="51" height="31"/>
+                                                <rect key="frame" x="316" y="0.0" width="51" height="31"/>
                                                 <color key="onTintColor" red="0.0" green="0.68235294117647061" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             </switch>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yKh-8G-Gpx">
-                                        <rect key="frame" x="0.0" y="379" width="310" height="33"/>
+                                        <rect key="frame" x="0.0" y="379" width="365" height="33"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RXi-Ax-BIt">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="33"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="33"/>
                                                 <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                                 <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1053,30 +1053,30 @@
             <objects>
                 <viewController storyboardIdentifier="ID_InventoryVC" id="oNn-rS-311" userLabel="CslRfid InventoryVC" customClass="CSLInventoryVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="pRh-tK-EoN">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="519"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PQo-0I-wbG">
-                                <rect key="frame" x="0.0" y="20" width="320" height="464"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="563"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="shd-oN-zI4" userLabel="Inventory Info">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="110"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="czC-EZ-xcz" userLabel="Inventory Info Results">
-                                                <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="110"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8cS-tz-Anl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="106.5" height="110"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="125" height="110"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZL8-Cc-yta" userLabel="Tag Count Result">
-                                                                <rect key="frame" x="5" y="50" width="96.5" height="50"/>
+                                                                <rect key="frame" x="5" y="50" width="115" height="50"/>
                                                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                                 <fontDescription key="fontDescription" name="Digital-7Mono" family="Digital-7 Mono" pointSize="30"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tag Count" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ct4-NV-OWg">
-                                                                <rect key="frame" x="11" y="17" width="84.5" height="17"/>
+                                                                <rect key="frame" x="11" y="17" width="103" height="17"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="17" id="IHJ-nD-UFM"/>
                                                                 </constraints>
@@ -1097,17 +1097,17 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aVp-JD-U7x">
-                                                        <rect key="frame" x="106.5" y="0.0" width="107" height="110"/>
+                                                        <rect key="frame" x="125" y="0.0" width="125" height="110"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fvw-l1-c1p" userLabel="Tag Rate Result">
-                                                                <rect key="frame" x="5" y="50" width="97" height="50"/>
+                                                                <rect key="frame" x="5" y="50" width="115" height="50"/>
                                                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                                 <fontDescription key="fontDescription" name="Digital-7Mono" family="Digital-7 Mono" pointSize="30"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tag Rate (t/s)" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X2K-3m-sGQ">
-                                                                <rect key="frame" x="2" y="16" width="103" height="17"/>
+                                                                <rect key="frame" x="2" y="16" width="121" height="17"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="17" id="kDN-8X-4yI"/>
                                                                 </constraints>
@@ -1128,10 +1128,10 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jdg-kc-Tph">
-                                                        <rect key="frame" x="213.5" y="0.0" width="106.5" height="110"/>
+                                                        <rect key="frame" x="250" y="0.0" width="125" height="110"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="owy-fP-hkz" userLabel="Unique Tag Rate Result">
-                                                                <rect key="frame" x="5" y="50" width="96.5" height="50"/>
+                                                                <rect key="frame" x="5" y="50" width="115" height="50"/>
                                                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="50" id="dpW-Z9-lNk"/>
@@ -1169,10 +1169,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qLb-9p-wlo" userLabel="Tag List">
-                                        <rect key="frame" x="0.0" y="110" width="320" height="294"/>
+                                        <rect key="frame" x="0.0" y="110" width="375" height="393"/>
                                         <subviews>
                                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="JYT-nT-n1P">
-                                                <rect key="frame" x="0.0" y="0.0" width="320" height="294"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="393"/>
                                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                             </tableView>
                                         </subviews>
@@ -1185,25 +1185,25 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4nZ-hz-rSc" userLabel="Status Bar">
-                                        <rect key="frame" x="0.0" y="404" width="320" height="30"/>
+                                        <rect key="frame" x="0.0" y="503" width="375" height="30"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Rfw-Gm-Sl2">
-                                                <rect key="frame" x="0.0" y="0.0" width="320" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="30"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Battery: -" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wUt-OK-DoQ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="106.5" height="30"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="125" height="30"/>
                                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mode: RFID" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Dv-40-Mfg">
-                                                        <rect key="frame" x="106.5" y="0.0" width="107" height="30"/>
+                                                        <rect key="frame" x="125" y="0.0" width="125" height="30"/>
                                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qV1-w8-8Lj" userLabel="Clear Button">
-                                                        <rect key="frame" x="213.5" y="0.0" width="106.5" height="30"/>
+                                                        <rect key="frame" x="250" y="0.0" width="125" height="30"/>
                                                         <fontDescription key="fontDescription" name="Lato-Bold" family="Lato" pointSize="15"/>
                                                         <state key="normal" title="Clear">
                                                             <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1225,10 +1225,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ntH-np-Bqs" userLabel="Send Tag">
-                                        <rect key="frame" x="0.0" y="434" width="320" height="30"/>
+                                        <rect key="frame" x="0.0" y="533" width="375" height="30"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yq9-DT-wii" userLabel="Send Tag Data">
-                                                <rect key="frame" x="0.0" y="0.0" width="320" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Bold" family="Lato" pointSize="15"/>
                                                 <state key="normal" title="Send Tag Data">
                                                     <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1253,7 +1253,7 @@
                                 </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kdx-wm-fgK" userLabel="Start/Stop button">
-                                <rect key="frame" x="5" y="484" width="310" height="30"/>
+                                <rect key="frame" x="5" y="583" width="365" height="30"/>
                                 <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="4qa-V9-AoZ"/>
@@ -1329,30 +1329,30 @@
             <objects>
                 <viewController storyboardIdentifier="ID_FuncVC" id="g9W-MI-doE" userLabel="CslRfid Special Functions" customClass="CSLMoreFunctionsVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5Nf-lz-qSk">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="v3Y-fT-zmB" userLabel="Functions Menu">
-                                <rect key="frame" x="0.0" y="20" width="320" height="548"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="qXZ-XG-Iae" userLabel="Row 1">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="137"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="162"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OYq-sK-OCM" userLabel="Multibank Inventory">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="137"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="187.5" height="162"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Hc-cO-miC" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="8" width="152" height="129"/>
+                                                        <rect key="frame" x="8" y="8" width="179.5" height="154"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Multibank Access" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pfY-fY-ntx" userLabel="Multibank Inventory">
-                                                                <rect key="frame" x="9" y="94.5" width="134.5" height="20.5"/>
+                                                                <rect key="frame" x="23" y="122" width="134.5" height="20.5"/>
                                                                 <color key="tintColor" red="0.0" green="0.25490196078431371" blue="0.52156862745098043" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" name="Lato-Bold" family="Lato" pointSize="17"/>
                                                                 <color key="textColor" red="0.0" green="0.25490196078431371" blue="0.52156862745098043" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="201-OD-FEi">
-                                                                <rect key="frame" x="36" y="12" width="80" height="80"/>
+                                                                <rect key="frame" x="36" y="12" width="107.5" height="107.5"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="201-OD-FEi" secondAttribute="height" multiplier="1:1" id="bM6-lG-qYL" userLabel="aspect = 1:1"/>
                                                                 </constraints>
@@ -1381,13 +1381,13 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J7Z-h2-OAn" userLabel="Filters">
-                                                <rect key="frame" x="160" y="0.0" width="160" height="137"/>
+                                                <rect key="frame" x="187.5" y="0.0" width="187.5" height="162"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uue-1p-i8S" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="8" width="144" height="129"/>
+                                                        <rect key="frame" x="8" y="8" width="171.5" height="154"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4e5-qD-7Km">
-                                                                <rect key="frame" x="27" y="9" width="84" height="84"/>
+                                                                <rect key="frame" x="27" y="9" width="111.5" height="111.5"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="4e5-qD-7Km" secondAttribute="height" multiplier="1:1" id="e5a-tb-H32" userLabel="aspect = 1:1"/>
                                                                 </constraints>
@@ -1397,7 +1397,7 @@
                                                                 </connections>
                                                             </button>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filters" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4rG-AM-uL5" userLabel="Filters">
-                                                                <rect key="frame" x="44.5" y="95" width="49" height="20.5"/>
+                                                                <rect key="frame" x="58.5" y="122.5" width="49" height="20.5"/>
                                                                 <color key="tintColor" red="0.0" green="0.25490196078431371" blue="0.52156862745098043" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" name="Lato-Bold" family="Lato" pointSize="17"/>
                                                                 <color key="textColor" red="0.0" green="0.25490196078431371" blue="0.52156862745098043" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1425,23 +1425,23 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="AvO-3s-BV2" userLabel="Row 2">
-                                        <rect key="frame" x="0.0" y="137" width="320" height="137"/>
+                                        <rect key="frame" x="0.0" y="162" width="375" height="161.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bU3-e7-XgP" userLabel="MQTT">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="137"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="187.5" height="161.5"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4ig-vT-LHb" userLabel="Tile">
-                                                        <rect key="frame" x="8" y="8" width="152" height="129"/>
+                                                        <rect key="frame" x="8" y="8" width="179.5" height="153.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MQTT" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qe3-Yv-TsS">
-                                                                <rect key="frame" x="51.5" y="93" width="49" height="20.5"/>
+                                                                <rect key="frame" x="65.5" y="120.5" width="49" height="20.5"/>
                                                                 <color key="tintColor" red="0.0" green="0.25490196078431371" blue="0.52156862745098043" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" name="Lato-Bold" family="Lato" pointSize="17"/>
                                                                 <color key="textColor" red="0.0" green="0.25490196078431371" blue="0.52156862745098043" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y4x-8b-F2Q">
-                                                                <rect key="frame" x="36" y="12" width="80" height="80"/>
+                                                                <rect key="frame" x="36" y="12" width="107.5" height="107.5"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" secondItem="y4x-8b-F2Q" secondAttribute="height" multiplier="1:1" id="sQT-CW-kkZ"/>
                                                                 </constraints>
@@ -1470,16 +1470,16 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ze9-Gz-6Nz" userLabel="TBD">
-                                                <rect key="frame" x="160" y="0.0" width="160" height="137"/>
+                                                <rect key="frame" x="187.5" y="0.0" width="187.5" height="161.5"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </view>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qdl-Fu-xgJ" userLabel="Row 3">
-                                        <rect key="frame" x="0.0" y="274" width="320" height="137"/>
+                                        <rect key="frame" x="0.0" y="323.5" width="375" height="162"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TSC-Td-nl3" userLabel="Row 4">
-                                        <rect key="frame" x="0.0" y="411" width="320" height="137"/>
+                                        <rect key="frame" x="0.0" y="485.5" width="375" height="161.5"/>
                                     </stackView>
                                 </subviews>
                             </stackView>
@@ -1503,14 +1503,14 @@
             <objects>
                 <viewController storyboardIdentifier="ID_MultibankVC" id="vTg-gF-cDw" userLabel="CslRfid Multibank AccessVC" customClass="CSLMultibankAccessVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="iDI-5E-BpG">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="g9t-Ha-LAI" userLabel="Multibank Elements">
-                                <rect key="frame" x="5" y="30" width="310" height="260"/>
+                                <rect key="frame" x="5" y="30" width="365" height="260"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hbx-Ek-M3M" userLabel="First Bank 1">
-                                        <rect key="frame" x="0.0" y="0.0" width="310" height="35"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="365" height="35"/>
                                         <subviews>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="zum-UA-X7b">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="35"/>
@@ -1520,13 +1520,13 @@
                                                 </connections>
                                             </switch>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Extra Bank 1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gq8-SJ-9Jw">
-                                                <rect key="frame" x="49" y="0.0" width="111" height="35"/>
+                                                <rect key="frame" x="49" y="0.0" width="166" height="35"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJg-Du-tG7">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="35"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="35"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="G5S-bn-z6K"/>
                                                 </constraints>
@@ -1539,16 +1539,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="hvg-DM-68F" userLabel="First Bank 2">
-                                        <rect key="frame" x="0.0" y="45" width="310" height="35"/>
+                                        <rect key="frame" x="0.0" y="45" width="365" height="35"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Offset   " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abO-u8-hkX">
-                                                <rect key="frame" x="0.0" y="0.0" width="77.5" height="35"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="91.5" height="35"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="0" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1uW-eJ-NT1">
-                                                <rect key="frame" x="77.5" y="0.0" width="77.5" height="35"/>
+                                                <rect key="frame" x="91.5" y="0.0" width="91" height="35"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -1557,13 +1557,13 @@
                                                 </connections>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Size   " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tj9-zT-8Nh">
-                                                <rect key="frame" x="155" y="0.0" width="77.5" height="35"/>
+                                                <rect key="frame" x="182.5" y="0.0" width="91.5" height="35"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="2" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6Le-9z-9gr">
-                                                <rect key="frame" x="232.5" y="0.0" width="77.5" height="35"/>
+                                                <rect key="frame" x="274" y="0.0" width="91" height="35"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -1574,7 +1574,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DME-rj-sby" userLabel="Second Bank 1">
-                                        <rect key="frame" x="0.0" y="90" width="310" height="35"/>
+                                        <rect key="frame" x="0.0" y="90" width="365" height="35"/>
                                         <subviews>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="4g5-ti-NW7">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="35"/>
@@ -1584,13 +1584,13 @@
                                                 </connections>
                                             </switch>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Extra Bank 2" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oIg-bC-BNe">
-                                                <rect key="frame" x="49" y="0.0" width="111" height="35"/>
+                                                <rect key="frame" x="49" y="0.0" width="166" height="35"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jVb-ID-5Hw" userLabel="USER">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="35"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="35"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="U1y-yf-fmq"/>
                                                 </constraints>
@@ -1603,16 +1603,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="3hg-Iv-GN4" userLabel="Second Bank 2">
-                                        <rect key="frame" x="0.0" y="135" width="310" height="35"/>
+                                        <rect key="frame" x="0.0" y="135" width="365" height="35"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Offset" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gjA-r8-vc9">
-                                                <rect key="frame" x="0.0" y="0.0" width="77.5" height="35"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="91.5" height="35"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="0" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="mEC-yr-brN">
-                                                <rect key="frame" x="77.5" y="0.0" width="77.5" height="35"/>
+                                                <rect key="frame" x="91.5" y="0.0" width="91" height="35"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -1621,13 +1621,13 @@
                                                 </connections>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Size   " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FPv-Zk-txp">
-                                                <rect key="frame" x="155" y="0.0" width="77.5" height="35"/>
+                                                <rect key="frame" x="182.5" y="0.0" width="91.5" height="35"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="2" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yxj-rN-5cF">
-                                                <rect key="frame" x="232.5" y="0.0" width="77.5" height="35"/>
+                                                <rect key="frame" x="274" y="0.0" width="91" height="35"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -1638,10 +1638,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EMW-iB-UJ6" userLabel="Save">
-                                        <rect key="frame" x="0.0" y="180" width="310" height="35"/>
+                                        <rect key="frame" x="0.0" y="180" width="365" height="35"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UsI-aa-9Gf" userLabel="Save Button">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="35"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="35"/>
                                                 <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                                 <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1653,10 +1653,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nrg-8O-6Q0">
-                                        <rect key="frame" x="0.0" y="225" width="310" height="35"/>
+                                        <rect key="frame" x="0.0" y="225" width="365" height="35"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Note: configurations above can be overridden by some of the special functions on the app." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6G7-6f-6sB">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="35"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="35"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -1701,7 +1701,7 @@
             <objects>
                 <viewController storyboardIdentifier="ID_AboutVC" title="About" id="X0q-ZB-cO0" userLabel="CslRfid AboutVC" customClass="CSLAboutVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1BB-be-uGa">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Bluetooth Firmware Version:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XSa-B2-gQS" userLabel="Bluetooth FW Version">
@@ -1811,17 +1811,17 @@
             <objects>
                 <viewController storyboardIdentifier="ID_TemperatureDetailsVC" id="0CS-Xr-TvH" userLabel="CslRfid Temperature Tag Details" customClass="CSLTemperatureDetailsVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="b9v-TH-DbC">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="J2e-ap-EWu">
-                                <rect key="frame" x="0.0" y="20" width="320" height="499"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="598"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u0d-BI-NQH" userLabel="Title View">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sensor Details" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fhB-1P-HUE">
-                                                <rect key="frame" x="97" y="18" width="126" height="24"/>
+                                                <rect key="frame" x="124.5" y="18" width="126" height="24"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="20"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -1835,10 +1835,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GsI-Jx-aVp" userLabel="Temperature View">
-                                        <rect key="frame" x="0.0" y="50" width="320" height="75"/>
+                                        <rect key="frame" x="0.0" y="50" width="375" height="75"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="99.9º" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1dm-IT-RTC" userLabel="Temperature">
-                                                <rect key="frame" x="122.5" y="0.0" width="75" height="75"/>
+                                                <rect key="frame" x="150" y="0.0" width="75" height="75"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="32"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -1853,10 +1853,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XXp-zW-fjK" userLabel="EPC View">
-                                        <rect key="frame" x="0.0" y="125" width="320" height="50"/>
+                                        <rect key="frame" x="0.0" y="125" width="375" height="50"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="1iW-kt-UyC">
-                                                <rect key="frame" x="47.5" y="0.0" width="225" height="50"/>
+                                                <rect key="frame" x="75" y="0.0" width="225" height="50"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BNm-DZ-6Eg" userLabel="Tag">
                                                         <rect key="frame" x="0.0" y="12.5" width="25" height="25"/>
@@ -1890,10 +1890,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="upL-a2-mhn" userLabel="Status View">
-                                        <rect key="frame" x="0.0" y="175" width="320" height="50"/>
+                                        <rect key="frame" x="0.0" y="175" width="375" height="50"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="IQd-or-FjG">
-                                                <rect key="frame" x="70" y="8" width="180" height="34"/>
+                                                <rect key="frame" x="97.5" y="8" width="180" height="34"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bSZ-ZF-ngB" userLabel="Temperature Icon">
                                                         <rect key="frame" x="0.0" y="4.5" width="25" height="25"/>
@@ -1926,10 +1926,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0lg-gh-nip" userLabel="Timestamp View">
-                                        <rect key="frame" x="0.0" y="225" width="320" height="45"/>
+                                        <rect key="frame" x="0.0" y="225" width="375" height="45"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="abn-V5-U1E">
-                                                <rect key="frame" x="70" y="0.0" width="180" height="25"/>
+                                                <rect key="frame" x="97.5" y="0.0" width="180" height="25"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NNi-1f-Nxm" userLabel="Timestamp Icon">
                                                         <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -1960,19 +1960,19 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dmw-QL-Ywb" userLabel="Tag Details View">
-                                        <rect key="frame" x="0.0" y="270" width="320" height="229"/>
+                                        <rect key="frame" x="0.0" y="270" width="375" height="328"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UZx-NJ-UgO">
-                                                <rect key="frame" x="5" y="5" width="310" height="219"/>
+                                                <rect key="frame" x="5" y="5" width="365" height="318"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="2Hu-Aw-JyW" userLabel="Tag Details Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="310" height="219"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="365" height="318"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UZ6-Oh-5QY">
-                                                                <rect key="frame" x="0.0" y="0.0" width="310" height="44"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="365" height="63.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Last Valid Sensor Reading:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mpG-wq-An4" userLabel="Last Sensor Reading">
-                                                                        <rect key="frame" x="18" y="13" width="171.5" height="18"/>
+                                                                        <rect key="frame" x="18" y="23" width="171.5" height="18"/>
                                                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -1985,10 +1985,10 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uvi-zS-lwQ">
-                                                                <rect key="frame" x="0.0" y="44" width="310" height="43.5"/>
+                                                                <rect key="frame" x="0.0" y="63.5" width="365" height="63.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Calibration:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BZX-bq-qCz">
-                                                                        <rect key="frame" x="18" y="12.5" width="140" height="18"/>
+                                                                        <rect key="frame" x="18" y="23" width="140" height="18"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="140" id="CZV-8S-cTu"/>
                                                                         </constraints>
@@ -1997,7 +1997,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0000000000000000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5RB-lZ-CeS" userLabel="Calibration Value">
-                                                                        <rect key="frame" x="158" y="12.5" width="139.5" height="18"/>
+                                                                        <rect key="frame" x="158" y="23" width="139.5" height="18"/>
                                                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -2012,10 +2012,10 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RiA-Zj-gcQ">
-                                                                <rect key="frame" x="0.0" y="87.5" width="310" height="44"/>
+                                                                <rect key="frame" x="0.0" y="127" width="365" height="64"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sensor Code:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BgV-Vn-QRH">
-                                                                        <rect key="frame" x="18" y="13" width="140" height="18"/>
+                                                                        <rect key="frame" x="18" y="23" width="140" height="18"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="140" id="Oag-7U-DU8"/>
                                                                         </constraints>
@@ -2024,7 +2024,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPn-Iw-r1a" userLabel="Sensor Code Value">
-                                                                        <rect key="frame" x="158" y="13" width="35" height="18"/>
+                                                                        <rect key="frame" x="158" y="23" width="35" height="18"/>
                                                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -2040,10 +2040,10 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8LG-cn-kaq">
-                                                                <rect key="frame" x="0.0" y="131.5" width="310" height="43.5"/>
+                                                                <rect key="frame" x="0.0" y="191" width="365" height="63.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sensor RSSI Code:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="948-ey-PMB">
-                                                                        <rect key="frame" x="18" y="13" width="140" height="18"/>
+                                                                        <rect key="frame" x="18" y="22.5" width="140" height="18"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="140" id="dpP-4l-T3y"/>
                                                                         </constraints>
@@ -2052,7 +2052,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zdq-WW-u4w" userLabel="Sensor RSSI Value">
-                                                                        <rect key="frame" x="158" y="13" width="35" height="18"/>
+                                                                        <rect key="frame" x="158" y="22.5" width="35" height="18"/>
                                                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -2068,10 +2068,10 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OIY-2H-RFe">
-                                                                <rect key="frame" x="0.0" y="175" width="310" height="44"/>
+                                                                <rect key="frame" x="0.0" y="254.5" width="365" height="63.5"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Temperature Code:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wuV-Tg-ixX">
-                                                                        <rect key="frame" x="18" y="13" width="140" height="18"/>
+                                                                        <rect key="frame" x="18" y="22.5" width="140" height="18"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="140" id="i2m-DI-0DD"/>
                                                                         </constraints>
@@ -2080,7 +2080,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MDg-Ow-7Jj" userLabel="Temperature Code Value">
-                                                                        <rect key="frame" x="158" y="13" width="35" height="18"/>
+                                                                        <rect key="frame" x="158" y="22.5" width="35" height="18"/>
                                                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -2153,23 +2153,30 @@
             <objects>
                 <viewController id="j72-cb-617" userLabel="CslRfid Temperature Tag Settings" customClass="CSLTemperatureTagSettingsVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Tmu-NG-s1n">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="sZY-Z6-7z5">
-                                <rect key="frame" x="0.0" y="20" width="320" height="499"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="590"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sh9-IV-vbJ">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="49"/>
                                         <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4bz-yd-agg">
+                                                <rect key="frame" x="157" y="10.5" width="210" height="28"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="210" id="MSa-x5-c4t"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                <state key="normal" title="Axzon Magnus S3 - Temperature">
+                                                    <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="btnSensorTypePressed:" destination="j72-cb-617" eventType="touchUpInside" id="SJ1-zx-h5m"/>
+                                                </connections>
+                                            </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sensor Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BFM-MJ-Ihe">
-                                                <rect key="frame" x="8" y="17" width="79.5" height="21.5"/>
-                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Axzon Magnues S3" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6q9-KV-Zii">
-                                                <rect key="frame" x="188" y="17" width="124" height="21.5"/>
+                                                <rect key="frame" x="8" y="15.5" width="79.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -2177,43 +2184,45 @@
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstItem="6q9-KV-Zii" firstAttribute="centerY" secondItem="Sh9-IV-vbJ" secondAttribute="centerY" id="Nax-bC-bbK"/>
-                                            <constraint firstItem="6q9-KV-Zii" firstAttribute="top" secondItem="Sh9-IV-vbJ" secondAttribute="top" constant="17" id="Upf-Ij-5Vr"/>
-                                            <constraint firstItem="BFM-MJ-Ihe" firstAttribute="leading" secondItem="Sh9-IV-vbJ" secondAttribute="leadingMargin" id="Vba-Py-o7Y"/>
-                                            <constraint firstItem="BFM-MJ-Ihe" firstAttribute="baseline" secondItem="6q9-KV-Zii" secondAttribute="baseline" id="Y3M-iG-Cl9"/>
+                                            <constraint firstItem="BFM-MJ-Ihe" firstAttribute="leading" secondItem="Sh9-IV-vbJ" secondAttribute="leading" constant="8" id="Avi-s5-KKJ"/>
+                                            <constraint firstAttribute="trailing" secondItem="4bz-yd-agg" secondAttribute="trailing" constant="8" id="EL9-2r-eJA"/>
+                                            <constraint firstItem="4bz-yd-agg" firstAttribute="centerY" secondItem="BFM-MJ-Ihe" secondAttribute="centerY" id="R0k-R0-Kcq"/>
                                             <constraint firstItem="BFM-MJ-Ihe" firstAttribute="centerY" secondItem="Sh9-IV-vbJ" secondAttribute="centerY" id="a3M-9D-RSD"/>
-                                            <constraint firstItem="6q9-KV-Zii" firstAttribute="trailing" secondItem="Sh9-IV-vbJ" secondAttribute="trailingMargin" id="kBO-1P-zkM"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z3G-FM-ET8">
-                                        <rect key="frame" x="0.0" y="55.5" width="320" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="49" width="375" height="49.5"/>
                                         <subviews>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="k1J-c1-a7E">
-                                                <rect key="frame" x="8" y="8" width="49" height="31"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="k1J-c1-a7E">
+                                                <rect key="frame" x="8" y="9.5" width="51" height="31"/>
                                                 <color key="onTintColor" red="0.0" green="0.68235294117647061" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             </switch>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Enable Temperature Alert" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9AD-2K-82U">
-                                                <rect key="frame" x="76" y="14" width="169" height="18"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Alert" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9AD-2K-82U">
+                                                <rect key="frame" x="285.5" y="16" width="81.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="9AD-2K-82U" firstAttribute="centerY" secondItem="z3G-FM-ET8" secondAttribute="centerY" id="26X-ew-ch2"/>
+                                            <constraint firstAttribute="trailing" secondItem="9AD-2K-82U" secondAttribute="trailing" constant="8" id="AhM-Ps-t59"/>
+                                            <constraint firstItem="k1J-c1-a7E" firstAttribute="leading" secondItem="z3G-FM-ET8" secondAttribute="leading" constant="8" id="euK-lR-fEQ"/>
+                                            <constraint firstItem="k1J-c1-a7E" firstAttribute="centerY" secondItem="9AD-2K-82U" secondAttribute="centerY" id="oBd-mh-4Lg"/>
+                                        </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hly-79-JhZ">
-                                        <rect key="frame" x="0.0" y="111" width="320" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="98.5" width="375" height="49"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Low Temperature Threshold" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X2x-nv-phg">
-                                                <rect key="frame" x="8" y="18.5" width="184.5" height="18"/>
+                                                <rect key="frame" x="8" y="15.5" width="184.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="2.0" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Keh-2c-fbf" userLabel="Low Temperature Threshold Value">
-                                                <rect key="frame" x="212" y="12.5" width="100" height="30"/>
+                                                <rect key="frame" x="267" y="9.5" width="100" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="100" id="XKd-9q-aHz"/>
                                                 </constraints>
@@ -2234,16 +2243,16 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hNf-No-gbq">
-                                        <rect key="frame" x="0.0" y="166.5" width="320" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="147.5" width="375" height="49"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="High Temperature Threshold" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NbP-47-njx">
-                                                <rect key="frame" x="8" y="18.5" width="188.5" height="18"/>
+                                                <rect key="frame" x="8" y="15.5" width="188.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="10.0" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rDU-PV-ZHA" userLabel="High Temperature Threshold Value">
-                                                <rect key="frame" x="212" y="12.5" width="100" height="30"/>
+                                                <rect key="frame" x="267" y="9.5" width="100" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="100" id="dVX-Es-Mmw"/>
                                                 </constraints>
@@ -2263,17 +2272,61 @@
                                             <constraint firstItem="NbP-47-njx" firstAttribute="centerY" secondItem="hNf-No-gbq" secondAttribute="centerY" id="Zoc-U8-uQC"/>
                                         </constraints>
                                     </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b1o-M3-I3k">
+                                        <rect key="frame" x="0.0" y="196.5" width="375" height="49.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Moisture Alert" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Uy-sj-Zmb">
+                                                <rect key="frame" x="8" y="16" width="97" height="18"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f4S-IZ-oUc">
+                                                <rect key="frame" x="113" y="10" width="49" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="49" id="4iG-sT-4Rx"/>
+                                                </constraints>
+                                                <state key="normal" title="&gt;">
+                                                    <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="btnMoistureComparePressed:" destination="j72-cb-617" eventType="touchUpInside" id="3mW-hy-sNp"/>
+                                                </connections>
+                                            </button>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="100" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LIz-Ge-acc">
+                                                <rect key="frame" x="267" y="10" width="100" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="100" id="5Ye-ne-xUe"/>
+                                                </constraints>
+                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                                <connections>
+                                                    <action selector="btnMoistureValueChanged:" destination="j72-cb-617" eventType="editingDidEnd" id="5WP-UY-1k6"/>
+                                                </connections>
+                                            </textField>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="7Uy-sj-Zmb" firstAttribute="leading" secondItem="b1o-M3-I3k" secondAttribute="leading" constant="8" id="3Pg-Fh-0Rd"/>
+                                            <constraint firstItem="7Uy-sj-Zmb" firstAttribute="centerY" secondItem="b1o-M3-I3k" secondAttribute="centerY" id="7nH-s4-3Pz"/>
+                                            <constraint firstItem="f4S-IZ-oUc" firstAttribute="centerY" secondItem="b1o-M3-I3k" secondAttribute="centerY" id="Jsg-d7-4Qt"/>
+                                            <constraint firstItem="f4S-IZ-oUc" firstAttribute="leading" secondItem="7Uy-sj-Zmb" secondAttribute="trailing" constant="8" symbolic="YES" id="SXe-87-5YT"/>
+                                            <constraint firstAttribute="trailing" secondItem="LIz-Ge-acc" secondAttribute="trailing" constant="8" id="WLM-AX-bHA"/>
+                                            <constraint firstItem="LIz-Ge-acc" firstAttribute="centerY" secondItem="b1o-M3-I3k" secondAttribute="centerY" id="fw3-er-W4B"/>
+                                        </constraints>
+                                    </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bkr-FB-wi8">
-                                        <rect key="frame" x="0.0" y="222" width="320" height="55"/>
+                                        <rect key="frame" x="0.0" y="246" width="375" height="49"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Min. On-chip RSSI" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xL0-RG-nzV">
-                                                <rect key="frame" x="8" y="18.5" width="118.5" height="18"/>
+                                                <rect key="frame" x="8" y="15.5" width="118.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="8" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="4SA-I2-UfI" userLabel="Min. On-chip RSSI Value">
-                                                <rect key="frame" x="212" y="12.5" width="100" height="30"/>
+                                                <rect key="frame" x="267" y="9.5" width="100" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="100" id="oPx-Ci-z4P"/>
                                                 </constraints>
@@ -2294,16 +2347,16 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CWg-hc-alj">
-                                        <rect key="frame" x="0.0" y="277" width="320" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="295" width="375" height="49"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Max. On-chip RSSI" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vL6-6w-djH">
-                                                <rect key="frame" x="8" y="19" width="121.5" height="18"/>
+                                                <rect key="frame" x="8" y="15.5" width="121.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="18" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3WA-nk-rfk">
-                                                <rect key="frame" x="212" y="13" width="100" height="30"/>
+                                                <rect key="frame" x="267" y="9.5" width="100" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="100" id="djx-uk-OD5"/>
                                                 </constraints>
@@ -2324,10 +2377,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EyR-H9-0Yr">
-                                        <rect key="frame" x="0.0" y="332.5" width="320" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="344" width="375" height="49.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Temperature Averaging" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="btr-zX-KiD">
-                                                <rect key="frame" x="8" y="19" width="153.5" height="18"/>
+                                                <rect key="frame" x="8" y="16" width="153.5" height="18"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="18" id="Z2I-yl-Jal"/>
                                                 </constraints>
@@ -2336,7 +2389,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="5" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zKZ-nu-zUM">
-                                                <rect key="frame" x="212" y="13" width="100" height="30"/>
+                                                <rect key="frame" x="267" y="10" width="100" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="100" id="AMn-sK-feu"/>
                                                 </constraints>
@@ -2357,16 +2410,16 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L98-eM-aYt">
-                                        <rect key="frame" x="0.0" y="388" width="320" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="393.5" width="375" height="49"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Temperature Unit" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BMF-PD-oSe">
-                                                <rect key="frame" x="8" y="19" width="116.5" height="18"/>
+                                                <rect key="frame" x="8" y="15.5" width="116.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="ck1-wB-krh">
-                                                <rect key="frame" x="192" y="14" width="120" height="29"/>
+                                                <rect key="frame" x="247" y="10.5" width="120" height="29"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="120" id="VTA-ev-TnQ"/>
                                                 </constraints>
@@ -2385,11 +2438,64 @@
                                             <constraint firstItem="ck1-wB-krh" firstAttribute="centerY" secondItem="L98-eM-aYt" secondAttribute="centerY" id="fcx-wD-D5m"/>
                                         </constraints>
                                     </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gkx-9L-hhr">
+                                        <rect key="frame" x="0.0" y="442.5" width="375" height="49"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Power Level" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wZf-G3-THT">
+                                                <rect key="frame" x="8" y="15.5" width="80" height="18"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JUy-yY-ql5" userLabel="Power Level Selection">
+                                                <rect key="frame" x="187" y="9.5" width="180" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="180" id="NBr-Wm-MF7"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
+                                                <state key="normal" title="Follow System Setting">
+                                                    <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="btnPowerLevelChanged:" destination="j72-cb-617" eventType="touchUpInside" id="xYP-gK-0cf"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="wZf-G3-THT" firstAttribute="centerY" secondItem="gkx-9L-hhr" secondAttribute="centerY" id="KRD-pd-VOz"/>
+                                            <constraint firstItem="JUy-yY-ql5" firstAttribute="centerY" secondItem="gkx-9L-hhr" secondAttribute="centerY" id="OgT-Kc-9hQ"/>
+                                            <constraint firstItem="wZf-G3-THT" firstAttribute="leading" secondItem="gkx-9L-hhr" secondAttribute="leading" constant="8" id="e4o-P0-e81"/>
+                                            <constraint firstAttribute="trailing" secondItem="JUy-yY-ql5" secondAttribute="trailing" constant="8" id="nGE-jJ-MCn"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="th5-rl-kQs">
+                                        <rect key="frame" x="0.0" y="491.5" width="375" height="49.5"/>
+                                        <subviews>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="C3Q-Fu-Auf">
+                                                <rect key="frame" x="8" y="9.5" width="51" height="31"/>
+                                                <color key="onTintColor" red="0.0" green="0.68235294117647061" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </switch>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Display Tag ID in ASCII" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VyR-yi-VWT">
+                                                <rect key="frame" x="218.5" y="16" width="148.5" height="18"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="C3Q-Fu-Auf" firstAttribute="centerY" secondItem="VyR-yi-VWT" secondAttribute="centerY" id="DU4-Qy-gef"/>
+                                            <constraint firstAttribute="trailing" secondItem="VyR-yi-VWT" secondAttribute="trailing" constant="8" id="Drw-jz-WzO"/>
+                                            <constraint firstItem="VyR-yi-VWT" firstAttribute="centerY" secondItem="th5-rl-kQs" secondAttribute="centerY" id="NEo-fC-Uo3"/>
+                                            <constraint firstItem="C3Q-Fu-Auf" firstAttribute="leading" secondItem="th5-rl-kQs" secondAttribute="leading" constant="8" id="w62-r3-8zi"/>
+                                        </constraints>
+                                    </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a8M-lb-kDO">
-                                        <rect key="frame" x="0.0" y="443.5" width="320" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="541" width="375" height="49"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wyG-mq-nM8">
-                                                <rect key="frame" x="8" y="8" width="304" height="33"/>
+                                                <rect key="frame" x="8" y="8" width="359" height="33"/>
                                                 <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                                 <color key="tintColor" red="0.93725490570000003" green="0.93725490570000003" blue="0.95686274770000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2408,12 +2514,18 @@
                                     </view>
                                 </subviews>
                             </stackView>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="eFD-LU-0pd">
+                                <rect key="frame" x="169" y="315" width="37" height="37"/>
+                                <color key="color" red="0.63921568627450975" green="0.63921568627450975" blue="0.63921568627450975" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="lwF-qp-vNt" firstAttribute="trailing" secondItem="sZY-Z6-7z5" secondAttribute="trailing" id="Coq-8d-MMs"/>
+                            <constraint firstItem="eFD-LU-0pd" firstAttribute="centerY" secondItem="Tmu-NG-s1n" secondAttribute="centerY" id="Dld-eL-ZHr"/>
+                            <constraint firstItem="eFD-LU-0pd" firstAttribute="centerX" secondItem="Tmu-NG-s1n" secondAttribute="centerX" id="Rto-P8-4ae"/>
                             <constraint firstItem="sZY-Z6-7z5" firstAttribute="leading" secondItem="lwF-qp-vNt" secondAttribute="leading" id="Wsk-RM-Y60"/>
-                            <constraint firstItem="lwF-qp-vNt" firstAttribute="bottom" secondItem="sZY-Z6-7z5" secondAttribute="bottom" id="Z22-H4-eym"/>
+                            <constraint firstItem="lwF-qp-vNt" firstAttribute="bottom" secondItem="sZY-Z6-7z5" secondAttribute="bottom" constant="8" id="Z22-H4-eym"/>
                             <constraint firstItem="sZY-Z6-7z5" firstAttribute="top" secondItem="lwF-qp-vNt" secondAttribute="top" id="mGc-Vn-L9t"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="lwF-qp-vNt"/>
@@ -2421,11 +2533,17 @@
                     <tabBarItem key="tabBarItem" title="Settings" image="rfm-settings" landscapeImage="rfm-settings" largeContentSizeImage="rfm-settings" id="1o7-aw-0ht"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="actSaveConfig" destination="eFD-LU-0pd" id="0ap-vY-gTA"/>
+                        <outlet property="btnMoistureCompare" destination="f4S-IZ-oUc" id="9Am-qc-l9n"/>
+                        <outlet property="btnPowerLevel" destination="JUy-yY-ql5" id="m0r-5A-a7g"/>
                         <outlet property="btnSave" destination="wyG-mq-nM8" id="vhI-FG-huF"/>
+                        <outlet property="btnSensorType" destination="4bz-yd-agg" id="3lT-b2-hfr"/>
                         <outlet property="scTemperatureUnit" destination="ck1-wB-krh" id="W32-fW-yuc"/>
+                        <outlet property="swDisplayTagInAscii" destination="C3Q-Fu-Auf" id="OZs-1n-spS"/>
                         <outlet property="swEnableTemperatureAlert" destination="k1J-c1-a7E" id="tfO-GH-qJA"/>
                         <outlet property="txtHighTemperatureThreshold" destination="rDU-PV-ZHA" id="9mU-1c-oev"/>
                         <outlet property="txtLowTemperatureThreshold" destination="Keh-2c-fbf" id="GjS-8c-s1Z"/>
+                        <outlet property="txtMoistureValue" destination="LIz-Ge-acc" id="xlT-br-yxo"/>
                         <outlet property="txtNumberOfTemperatureAveraging" destination="zKZ-nu-zUM" id="Ixg-Nd-ZWo"/>
                         <outlet property="txtOcrssiMax" destination="3WA-nk-rfk" id="eaI-Md-QgW"/>
                         <outlet property="txtOcrssiMin" destination="4SA-I2-UfI" id="OD9-9z-Rcg"/>
@@ -2440,11 +2558,11 @@
             <objects>
                 <viewController id="KkZ-82-dg0" userLabel="CslRfid Temperature Tag Upload" customClass="CSLTemperatureUploadVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="LvH-Ge-MiT">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dSd-N2-8Sh" userLabel="MQTT Status Button">
-                                <rect key="frame" x="85" y="208" width="150" height="30"/>
+                                <rect key="frame" x="112.5" y="208" width="150" height="30"/>
                                 <color key="backgroundColor" red="0.63921568627450975" green="0.63921568627450975" blue="0.63921568627450975" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="4At-hi-0ru"/>
@@ -2455,25 +2573,25 @@
                                 <state key="normal" title="OFFLINE"/>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number of Records: -" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pkm-Tr-lhN">
-                                <rect key="frame" x="81" y="258" width="158" height="21"/>
+                                <rect key="frame" x="108.5" y="258" width="158" height="20"/>
                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="devices/{deviceId}/messages/events/" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="SiA-vG-TOw" userLabel="Publish Topic Text">
-                                <rect key="frame" x="20" y="320" width="280" height="30"/>
+                                <rect key="frame" x="20" y="319" width="335" height="30"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Publish to Topic:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="izk-vN-mQS">
-                                <rect key="frame" x="106.5" y="294" width="107" height="18"/>
+                                <rect key="frame" x="134" y="293" width="107" height="18"/>
                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tYY-tp-tY8">
-                                <rect key="frame" x="20" y="358" width="280" height="33"/>
+                                <rect key="frame" x="20" y="357" width="335" height="33"/>
                                 <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                 <color key="tintColor" red="0.93725490570000003" green="0.93725490570000003" blue="0.95686274770000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2483,7 +2601,7 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3DD-BR-tCD">
-                                <rect key="frame" x="96" y="52" width="128" height="128"/>
+                                <rect key="frame" x="123.5" y="52" width="128" height="128"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="cloud-offline" translatesAutoresizingMaskIntoConstraints="NO" id="hJV-Ao-sxN">
                                         <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
@@ -2504,6 +2622,17 @@
                                     <constraint firstAttribute="bottom" secondItem="hJV-Ao-sxN" secondAttribute="bottom" id="yoZ-AT-Y0i"/>
                                 </constraints>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wjw-Xx-9N2">
+                                <rect key="frame" x="81" y="410" width="158" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" red="0.63921568627450975" green="0.63921568627450975" blue="0.63921568627450975" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
+                                <color key="tintColor" red="0.93725490570000003" green="0.93725490570000003" blue="0.95686274770000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <state key="normal" title="Save to File"/>
+                                <connections>
+                                    <action selector="btnSaveToFilePressed:" destination="KkZ-82-dg0" eventType="touchUpInside" id="AOB-0K-8Mf"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
@@ -2531,6 +2660,7 @@
                         <outlet property="actMQTTConnectIndicator" destination="Nho-i5-Jik" id="EIr-dG-3LY"/>
                         <outlet property="btnMQTTStatus" destination="dSd-N2-8Sh" id="Z4G-yl-7qk"/>
                         <outlet property="btnMQTTUpload" destination="tYY-tp-tY8" id="WkZ-U9-BGL"/>
+                        <outlet property="btnSaveToFile" destination="wjw-Xx-9N2" id="WdH-La-gCc"/>
                         <outlet property="imgMQTTStatus" destination="hJV-Ao-sxN" id="LBk-YK-Zrz"/>
                         <outlet property="lbMQTTMessage" destination="pkm-Tr-lhN" id="yS8-zy-ZGE"/>
                         <outlet property="txtMQTTPublishTopic" destination="SiA-vG-TOw" id="uGi-Zd-KfY"/>
@@ -2545,20 +2675,20 @@
             <objects>
                 <viewController storyboardIdentifier="ID_TemperatureReadVC" id="KVe-mu-WoI" userLabel="CslRfid TempReadVC" customClass="CSLTemperatureReadVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="eML-Rv-QeN">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ECd-sd-ZFW" userLabel="Read Temperature">
-                                <rect key="frame" x="0.0" y="20" width="320" height="499"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="598"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="toK-YW-5KY" userLabel="Info Section">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fSy-Lq-3iz" userLabel="Start Button Tile" customClass="UIControl">
-                                                <rect key="frame" x="0.0" y="0.0" width="64" height="50"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="75" height="50"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vbJ-fe-XH0">
-                                                        <rect key="frame" x="19.5" y="19" width="25" height="25"/>
+                                                        <rect key="frame" x="25" y="19" width="25" height="25"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="vbJ-fe-XH0" secondAttribute="height" multiplier="1:1" id="HyU-up-2x6"/>
                                                         </constraints>
@@ -2568,7 +2698,7 @@
                                                         </connections>
                                                     </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3KT-89-MQt">
-                                                        <rect key="frame" x="3" y="0.0" width="58" height="15"/>
+                                                        <rect key="frame" x="3" y="0.0" width="69" height="15"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="15" id="jbo-lb-0Kc"/>
                                                         </constraints>
@@ -2591,10 +2721,10 @@
                                                 </connections>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gq9-uy-oGZ" userLabel="Battery Level Tile">
-                                                <rect key="frame" x="64" y="0.0" width="64" height="50"/>
+                                                <rect key="frame" x="75" y="0.0" width="75" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d1Q-Jl-age">
-                                                        <rect key="frame" x="30" y="0.0" width="4.5" height="15"/>
+                                                        <rect key="frame" x="35.5" y="0.0" width="4.5" height="15"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="15" id="QW6-aC-AmA"/>
                                                         </constraints>
@@ -2603,7 +2733,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cBl-7b-hKS">
-                                                        <rect key="frame" x="20" y="20" width="24" height="24"/>
+                                                        <rect key="frame" x="25.5" y="20" width="24" height="24"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="cBl-7b-hKS" secondAttribute="height" multiplier="1:1" id="wkF-e7-tfq"/>
                                                         </constraints>
@@ -2620,16 +2750,16 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8XC-UF-PrT" userLabel="Tag Count Tile">
-                                                <rect key="frame" x="128" y="0.0" width="64" height="50"/>
+                                                <rect key="frame" x="150" y="0.0" width="75" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eDq-jn-Sda">
-                                                        <rect key="frame" x="5" y="20" width="54" height="24"/>
+                                                        <rect key="frame" x="5" y="20" width="65" height="24"/>
                                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                         <color key="textColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Count" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Idq-07-e3o">
-                                                        <rect key="frame" x="7" y="0.0" width="50" height="15"/>
+                                                        <rect key="frame" x="7" y="0.0" width="61" height="15"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="15" id="3ce-jb-bDS"/>
                                                         </constraints>
@@ -2650,10 +2780,10 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pop-eW-cqM" userLabel="Tag Select Tile" customClass="UIControl">
-                                                <rect key="frame" x="192" y="0.0" width="64" height="50"/>
+                                                <rect key="frame" x="225" y="0.0" width="75" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="All" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6lu-fV-QLv">
-                                                        <rect key="frame" x="25" y="0.0" width="14.5" height="15"/>
+                                                        <rect key="frame" x="30.5" y="0.0" width="14.5" height="15"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="15" id="vNl-zq-8Vl"/>
                                                         </constraints>
@@ -2662,7 +2792,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2zK-1O-NHL">
-                                                        <rect key="frame" x="20" y="20" width="24" height="24"/>
+                                                        <rect key="frame" x="25.5" y="20" width="24" height="24"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="2zK-1O-NHL" secondAttribute="height" multiplier="1:1" id="ZXd-U0-QGX"/>
                                                         </constraints>
@@ -2685,10 +2815,10 @@
                                                 </connections>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qH8-l0-usL" userLabel="Tag Remove Tile" customClass="UIControl">
-                                                <rect key="frame" x="256" y="0.0" width="64" height="50"/>
+                                                <rect key="frame" x="300" y="0.0" width="75" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remove" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PDZ-IZ-m4U">
-                                                        <rect key="frame" x="10.5" y="0.0" width="43" height="15"/>
+                                                        <rect key="frame" x="16" y="0.0" width="43" height="15"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="15" id="HQb-WB-Cle"/>
                                                         </constraints>
@@ -2697,7 +2827,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rfd-tG-F8O">
-                                                        <rect key="frame" x="20" y="20" width="24" height="24"/>
+                                                        <rect key="frame" x="25.5" y="20" width="24" height="24"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="Rfd-tG-F8O" secondAttribute="height" multiplier="1:1" id="cmk-yv-EOm"/>
                                                         </constraints>
@@ -2722,10 +2852,10 @@
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vEt-k9-Y4C" userLabel="TagList Tile">
-                                        <rect key="frame" x="0.0" y="50" width="320" height="449"/>
+                                        <rect key="frame" x="0.0" y="50" width="375" height="548"/>
                                         <subviews>
-                                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsMultipleSelection="YES" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="KBI-jG-A7L" userLabel="Tag Table">
-                                                <rect key="frame" x="0.0" y="0.0" width="320" height="449"/>
+                                            <tableView clipsSubviews="YES" tag="1" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsMultipleSelection="YES" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="KBI-jG-A7L" userLabel="Tag Table">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="548"/>
                                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                             </tableView>
                                         </subviews>
@@ -2805,14 +2935,14 @@
             <objects>
                 <viewController storyboardIdentifier="ID_TagAccessVC" id="E7F-yr-253" userLabel="CslRfid TagAccessVC" customClass="CSLTagAccessVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="rQb-i9-LEN">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="11u-9g-wtT" userLabel="Tag Access Elements">
-                                <rect key="frame" x="5" y="40" width="310" height="523"/>
+                                <rect key="frame" x="5" y="40" width="365" height="523"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="tgk-ow-xrg" userLabel="Selected EPC">
-                                        <rect key="frame" x="0.0" y="0.0" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Selected EPC:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Dvj-ma-wpX" userLabel="Selected EPC">
                                                 <rect key="frame" x="0.0" y="0.0" width="91.5" height="30"/>
@@ -2821,7 +2951,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="OI8-4u-aK4" userLabel="Selected EPC Text">
-                                                <rect key="frame" x="96.5" y="0.0" width="213.5" height="30"/>
+                                                <rect key="frame" x="96.5" y="0.0" width="268.5" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -2833,7 +2963,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Zsf-g3-zMD" userLabel="Access PWD">
-                                        <rect key="frame" x="0.0" y="35" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="35" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Access PWD:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Np-QF-PWQ" userLabel="Access PWD">
                                                 <rect key="frame" x="0.0" y="0.0" width="88" height="30"/>
@@ -2842,7 +2972,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="00000000" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dRS-Y3-KlV" userLabel="Access PWD Text">
-                                                <rect key="frame" x="93" y="0.0" width="217" height="30"/>
+                                                <rect key="frame" x="93" y="0.0" width="272" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -2854,7 +2984,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="f99-kR-uda" userLabel="PC">
-                                        <rect key="frame" x="0.0" y="70" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="70" width="365" height="31"/>
                                         <subviews>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P5E-CQ-NWU">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
@@ -2871,7 +3001,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="m4Q-TP-bMC" userLabel="PC Text">
-                                                <rect key="frame" x="82.5" y="0.0" width="227.5" height="31"/>
+                                                <rect key="frame" x="82.5" y="0.0" width="282.5" height="31"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -2883,7 +3013,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="X9g-o9-OGk" userLabel="EPC">
-                                        <rect key="frame" x="0.0" y="106" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="106" width="365" height="31"/>
                                         <subviews>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jhA-Xn-jYo">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
@@ -2900,7 +3030,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fbL-tJ-qBi" userLabel="EPC Text">
-                                                <rect key="frame" x="91" y="0.0" width="219" height="31"/>
+                                                <rect key="frame" x="91" y="0.0" width="274" height="31"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -2912,7 +3042,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="eE0-du-pe3" userLabel="ACC PWD">
-                                        <rect key="frame" x="0.0" y="142" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="142" width="365" height="31"/>
                                         <subviews>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7hd-ca-W2y">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
@@ -2929,7 +3059,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="00000000" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="d9S-Mq-RhR" userLabel="ACC PWD Text">
-                                                <rect key="frame" x="132" y="0.0" width="178" height="31"/>
+                                                <rect key="frame" x="132" y="0.0" width="233" height="31"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -2941,7 +3071,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="bWw-R7-zdN" userLabel="KILL PWD">
-                                        <rect key="frame" x="0.0" y="178" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="178" width="365" height="31"/>
                                         <subviews>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fTq-HM-Y9z">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
@@ -2958,7 +3088,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="00000000" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eYC-0U-eqn" userLabel="KILL PWD Text">
-                                                <rect key="frame" x="132" y="0.0" width="178" height="31"/>
+                                                <rect key="frame" x="132" y="0.0" width="233" height="31"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -2970,7 +3100,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="car-4X-Dmm" userLabel="TID-UID">
-                                        <rect key="frame" x="0.0" y="214" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="214" width="365" height="31"/>
                                         <subviews>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BFh-Vb-a28">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
@@ -2987,7 +3117,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Dz-fH-AUX" userLabel="Offset=0">
-                                                <rect key="frame" x="120" y="0.0" width="129" height="31"/>
+                                                <rect key="frame" x="120" y="0.0" width="184" height="31"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <state key="normal" title="Offset=0"/>
                                                 <connections>
@@ -2996,7 +3126,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XBW-4B-c9S" userLabel="Word=2">
-                                                <rect key="frame" x="254" y="0.0" width="56" height="31"/>
+                                                <rect key="frame" x="309" y="0.0" width="56" height="31"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <state key="normal" title="Word=2"/>
                                                 <connections>
@@ -3007,10 +3137,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="1Lc-aK-DGa" userLabel="TID-UID Text">
-                                        <rect key="frame" x="0.0" y="250" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="250" width="365" height="30"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="v6U-FT-pLN" userLabel="TID-UID Text">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -3022,7 +3152,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="aHF-Mc-N3o" userLabel="USER">
-                                        <rect key="frame" x="0.0" y="285" width="310" height="31"/>
+                                        <rect key="frame" x="0.0" y="285" width="365" height="31"/>
                                         <subviews>
                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zxw-I4-nc8">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
@@ -3039,7 +3169,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="15O-wC-ouU" userLabel="Offset=0">
-                                                <rect key="frame" x="100.5" y="0.0" width="148.5" height="31"/>
+                                                <rect key="frame" x="100.5" y="0.0" width="203.5" height="31"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <state key="normal" title="Offset=0"/>
                                                 <connections>
@@ -3048,7 +3178,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MIV-LG-7rP" userLabel="Word=2">
-                                                <rect key="frame" x="254" y="0.0" width="56" height="31"/>
+                                                <rect key="frame" x="309" y="0.0" width="56" height="31"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <state key="normal" title="Word=2"/>
                                                 <connections>
@@ -3059,10 +3189,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="SI4-wh-3tL" userLabel="USER Text">
-                                        <rect key="frame" x="0.0" y="321" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="321" width="365" height="30"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nFZ-aU-y6U" userLabel="USER Text">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -3073,10 +3203,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="LNt-Jc-Lqq" userLabel="Read Write Button">
-                                        <rect key="frame" x="0.0" y="356" width="310" height="33"/>
+                                        <rect key="frame" x="0.0" y="356" width="365" height="33"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yX4-Bg-c1f" userLabel="Read">
-                                                <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="177.5" height="33"/>
                                                 <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                                 <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3087,7 +3217,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CpE-Vt-OqX" userLabel="Write">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="33"/>
+                                                <rect key="frame" x="187.5" y="0.0" width="177.5" height="33"/>
                                                 <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                                 <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3100,7 +3230,7 @@
                                         </subviews>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QCP-cA-sdM">
-                                        <rect key="frame" x="0.0" y="394" width="310" height="33"/>
+                                        <rect key="frame" x="0.0" y="394" width="365" height="33"/>
                                         <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3110,10 +3240,10 @@
                                         </connections>
                                     </button>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BfG-ti-vb2" userLabel="Messages">
-                                        <rect key="frame" x="0.0" y="432" width="310" height="91"/>
+                                        <rect key="frame" x="0.0" y="432" width="365" height="91"/>
                                         <subviews>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="rL2-ug-HHr" userLabel="Messages">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="91"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="91"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="91" id="kZA-xU-YAW"/>
@@ -3170,14 +3300,14 @@
             <objects>
                 <viewController storyboardIdentifier="ID_TagLockVC" id="b91-Xa-QNn" userLabel="CslRfid TagLockVC" customClass="CSLTagLockVC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="m6w-hl-6zC">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleAspectFit" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="kRH-ul-oKq" userLabel="Tag Lock Elements">
-                                <rect key="frame" x="5" y="40" width="310" height="508"/>
+                                <rect key="frame" x="5" y="40" width="365" height="607"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7NR-cb-0bd" userLabel="Selected EPC">
-                                        <rect key="frame" x="0.0" y="0.0" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Selected EPC: " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VBl-LQ-CtY" userLabel="Selected EPC">
                                                 <rect key="frame" x="0.0" y="0.0" width="94.5" height="30"/>
@@ -3186,7 +3316,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yyF-ix-1ux" userLabel="Selected EPC Text">
-                                                <rect key="frame" x="94.5" y="0.0" width="215.5" height="30"/>
+                                                <rect key="frame" x="94.5" y="0.0" width="270.5" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -3194,7 +3324,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FDv-GL-tJh">
-                                        <rect key="frame" x="0.0" y="35" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="35" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Access PWD: " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C5y-4o-dAs">
                                                 <rect key="frame" x="0.0" y="0.0" width="90.5" height="30"/>
@@ -3203,7 +3333,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="00000000" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZeT-YF-bSO">
-                                                <rect key="frame" x="90.5" y="0.0" width="219.5" height="30"/>
+                                                <rect key="frame" x="90.5" y="0.0" width="274.5" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -3211,16 +3341,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nl4-Yw-aI7">
-                                        <rect key="frame" x="0.0" y="70" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="70" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="EPC " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GhJ-SR-edx">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="215" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rh2-8S-FaT">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="30"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="uZN-Nc-IAF"/>
                                                 </constraints>
@@ -3235,16 +3365,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ijm-Li-ew1">
-                                        <rect key="frame" x="0.0" y="105" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="105" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ACC PWD" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hTR-oR-oS6">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="215" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FKH-2w-0sr">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="30"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="8fd-CO-WeE"/>
                                                 </constraints>
@@ -3259,16 +3389,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0YG-hB-oMI">
-                                        <rect key="frame" x="0.0" y="140" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="140" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KILL PWD" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MUG-bK-eYk">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="215" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZC5-aO-ncc">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="30"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="BD9-vv-o2A"/>
                                                 </constraints>
@@ -3283,16 +3413,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gHA-5j-ia5">
-                                        <rect key="frame" x="0.0" y="175" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="175" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="han-LB-oNt">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="215" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4z2-LJ-Pxc">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="30"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="kYG-L8-RwD"/>
                                                 </constraints>
@@ -3307,16 +3437,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h4o-ei-HtX">
-                                        <rect key="frame" x="0.0" y="210" width="310" height="30"/>
+                                        <rect key="frame" x="0.0" y="210" width="365" height="30"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="USER" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XbV-oH-cVY">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="215" height="30"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ccx-8d-ooX">
-                                                <rect key="frame" x="160" y="0.0" width="150" height="30"/>
+                                                <rect key="frame" x="215" y="0.0" width="150" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="0Nh-CM-G6q"/>
                                                 </constraints>
@@ -3331,10 +3461,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FPW-wG-ocM">
-                                        <rect key="frame" x="0.0" y="245" width="310" height="54"/>
+                                        <rect key="frame" x="0.0" y="245" width="365" height="153"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tW2-S1-Sg6">
-                                                <rect key="frame" x="0.0" y="0.0" width="310" height="54"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="365" height="153"/>
                                                 <color key="backgroundColor" red="0.29411764705882354" green="0.46666666666666667" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                                 <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3346,7 +3476,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oja-LX-PE1">
-                                        <rect key="frame" x="0.0" y="304" width="310" height="204"/>
+                                        <rect key="frame" x="0.0" y="403" width="365" height="204"/>
                                     </stackView>
                                 </subviews>
                             </stackView>
@@ -3377,30 +3507,30 @@
         </scene>
     </scenes>
     <resources>
-        <image name="Access" width="409.60000610351562" height="409.60000610351562"/>
-        <image name="Access-icon" width="50" height="50"/>
-        <image name="Battery-icon" width="50" height="50"/>
-        <image name="Check-icon" width="50" height="50"/>
-        <image name="Delete-icon" width="50" height="50"/>
-        <image name="Inventory" width="409.60000610351562" height="409.60000610351562"/>
-        <image name="MQTT" width="384" height="384"/>
-        <image name="Search" width="409.60000610351562" height="409.60000610351562"/>
-        <image name="Search-icon" width="50" height="50"/>
-        <image name="Start-icon" width="50" height="50"/>
-        <image name="Temperature-2" width="192" height="192"/>
-        <image name="clock" width="192" height="192"/>
-        <image name="cloud-offline" width="192" height="192"/>
-        <image name="disconnected" width="409.60000610351562" height="409.60000610351562"/>
-        <image name="filter" width="409.60000610351562" height="409.60000610351562"/>
-        <image name="function" width="384" height="384"/>
-        <image name="inventory-icon" width="50" height="50"/>
-        <image name="multibank" width="384" height="384"/>
-        <image name="rfm-info" width="50" height="50"/>
-        <image name="rfm-settings" width="50" height="50"/>
-        <image name="rfm-temperature" width="50" height="50"/>
-        <image name="rfm-upload" width="50" height="50"/>
-        <image name="settings" width="409.60000610351562" height="409.60000610351562"/>
-        <image name="tag" width="192" height="192"/>
-        <image name="temperature" width="384" height="384"/>
+        <image name="Access" width="512" height="512"/>
+        <image name="Access-icon" width="25" height="25"/>
+        <image name="Battery-icon" width="25" height="25"/>
+        <image name="Check-icon" width="25" height="25"/>
+        <image name="Delete-icon" width="25" height="25"/>
+        <image name="Inventory" width="512" height="512"/>
+        <image name="MQTT" width="512" height="512"/>
+        <image name="Search" width="512" height="512"/>
+        <image name="Search-icon" width="25" height="25"/>
+        <image name="Start-icon" width="25" height="25"/>
+        <image name="Temperature-2" width="256" height="256"/>
+        <image name="clock" width="240" height="240"/>
+        <image name="cloud-offline" width="256" height="256"/>
+        <image name="disconnected" width="512" height="512"/>
+        <image name="filter" width="512" height="512"/>
+        <image name="function" width="512" height="512"/>
+        <image name="inventory-icon" width="25" height="25"/>
+        <image name="multibank" width="512" height="512"/>
+        <image name="rfm-info" width="25" height="25"/>
+        <image name="rfm-settings" width="25" height="25"/>
+        <image name="rfm-temperature" width="25" height="25"/>
+        <image name="rfm-upload" width="25" height="25"/>
+        <image name="settings" width="512" height="512"/>
+        <image name="tag" width="256" height="256"/>
+        <image name="temperature" width="480" height="480"/>
     </resources>
 </document>

--- a/CS108iOSClient/Info.plist
+++ b/CS108iOSClient/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3</string>
+	<string>2.4</string>
 	<key>CFBundleVersion</key>
-	<string>2200</string>
+	<string>2379</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSBluetoothPeripheralUsageDescription</key>

--- a/CS108iOSClient/Info.plist
+++ b/CS108iOSClient/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.3</string>
 	<key>CFBundleVersion</key>
-	<string>2197</string>
+	<string>2200</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSBluetoothPeripheralUsageDescription</key>

--- a/CS108iOSClient/ViewControllers/CSLHomeVC.m
+++ b/CS108iOSClient/ViewControllers/CSLHomeVC.m
@@ -52,6 +52,9 @@
     self.view.userInteractionEnabled=true;
     self.btnReadTemperature.layer.opacity=1.0;
     
+    //reload configurations from Users Defaults to memory
+    [[CSLRfidAppEngine sharedAppEngine] reloadSettingsFromUserDefaults];
+    
     //check if reader is connected
     if ([CSLRfidAppEngine sharedAppEngine].reader.connectStatus!=NOT_CONNECTED) {
         self.lbConnectReader.text=[NSString stringWithFormat:@"Connected: %@", [CSLRfidAppEngine sharedAppEngine].reader.deviceName];

--- a/CS108iOSClient/ViewControllers/CSLTemperatureTabVC.h
+++ b/CS108iOSClient/ViewControllers/CSLTemperatureTabVC.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setActiveView:(int)identifier;
+- (void) setConfigurationsForTemperatureTags;
 
 @end
 

--- a/CS108iOSClient/ViewControllers/CSLTemperatureTabVC.m
+++ b/CS108iOSClient/ViewControllers/CSLTemperatureTabVC.m
@@ -20,6 +20,12 @@
     self.delegate = self;
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    
+    //clear all tag select
+    [[CSLRfidAppEngine sharedAppEngine].reader clearAllTagSelect];
+
+}
 /*
  #pragma mark - Navigation
  
@@ -89,5 +95,109 @@
     
     return YES;
 }
+
+- (void) setConfigurationsForTemperatureTags {
+    
+    //pre-configure inventory
+    //hardcode multibank inventory parameter for RFMicron tag reading (EPC+OCRSSI+TEMPERATURE)
+    [CSLRfidAppEngine sharedAppEngine].settings.isMultibank1Enabled = true;
+    [CSLRfidAppEngine sharedAppEngine].settings.isMultibank2Enabled = true;
+    
+    //check and see if this is S2 or S3 chip for capturing sensor code
+    [CSLRfidAppEngine sharedAppEngine].settings.multibank1=RESERVED;
+    if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.sensorType==MAGNUSS3) {
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank1Offset=12;    //word address 0xC in the RESERVE bank
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank1Length=3;
+    }
+    else {
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank1Offset=11;    //word address 0xB in the RESERVE bank
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank1Length=1;
+    }
+    
+    if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.sensorType==MAGNUSS3) {
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank2=USER;
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank2Offset=8;
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank2Length=4;
+    }
+    else {
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank2=RESERVED;
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank2Offset=13;
+        [CSLRfidAppEngine sharedAppEngine].settings.multibank2Length=1;
+    }
+    //for multiplebank inventory
+    Byte tagRead=0;
+    if ([CSLRfidAppEngine sharedAppEngine].settings.isMultibank1Enabled && [CSLRfidAppEngine sharedAppEngine].settings.isMultibank2Enabled)
+        tagRead=2;
+    else if ([CSLRfidAppEngine sharedAppEngine].settings.isMultibank1Enabled)
+        tagRead=1;
+    else
+        tagRead=0;
+    
+    if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel==HIGHPOWER)
+        [[CSLRfidAppEngine sharedAppEngine].reader setPower:30];
+    else if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel==LOWPOWER)
+        [[CSLRfidAppEngine sharedAppEngine].reader setPower:16];
+    else if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel==MEDIUMPOWER)
+        [[CSLRfidAppEngine sharedAppEngine].reader setPower:23];
+    else
+        [[CSLRfidAppEngine sharedAppEngine].reader setPower:[CSLRfidAppEngine sharedAppEngine].settings.power / 10];
+    
+    [[CSLRfidAppEngine sharedAppEngine].reader setAntennaCycle:COMMAND_ANTCYCLE_CONTINUOUS];    //0x0700
+    [[CSLRfidAppEngine sharedAppEngine].reader setAntennaDwell:0x00000000];  //0x0705
+    
+    [[CSLRfidAppEngine sharedAppEngine].reader selectAlgorithmParameter:DYNAMICQ];
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryAlgorithmParameters0:[CSLRfidAppEngine sharedAppEngine].settings.QValue maximumQ:15 minimumQ:0 ThresholdMultiplier:4];   //0x0903
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryAlgorithmParameters1:5];
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryAlgorithmParameters2:([CSLRfidAppEngine sharedAppEngine].settings.target == ToggleAB ? true : false) RunTillZero:false];     //x0905
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryConfigurations:DYNAMICQ MatchRepeats:0 tagSelect:0 disableInventory:0 tagRead:0 crcErrorRead:0 QTMode:0 tagDelay:0 inventoryMode:0]; //0x0901
+    
+    [[CSLRfidAppEngine sharedAppEngine].reader selectAlgorithmParameter:FIXEDQ];
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryAlgorithmParameters0:[CSLRfidAppEngine sharedAppEngine].settings.QValue maximumQ:0 minimumQ:0 ThresholdMultiplier:0];   //0x0903
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryAlgorithmParameters1:5];
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryAlgorithmParameters2:([CSLRfidAppEngine sharedAppEngine].settings.target == ToggleAB ? true : false) RunTillZero:false];     //x0905
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryConfigurations:FIXEDQ MatchRepeats:0 tagSelect:0 disableInventory:0 tagRead:0 crcErrorRead:0 QTMode:0 tagDelay:0 inventoryMode:0]; //0x0901
+    
+    [[CSLRfidAppEngine sharedAppEngine].reader setQueryConfigurations:A querySession:S1 querySelect:SL];
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryConfigurations:DYNAMICQ MatchRepeats:0 tagSelect:0 disableInventory:0 tagRead:0 crcErrorRead:0 QTMode:0 tagDelay:0 inventoryMode:0]; //0x0901
+    [[CSLRfidAppEngine sharedAppEngine].reader setLinkProfile:RANGE_DRM];
+    
+    //multiple bank select
+    unsigned char emptyByte[] = {0x00};
+    unsigned char OCRSSI[] = {0x20};
+    
+    //select the TID for either S2 or S3 chip
+    [[CSLRfidAppEngine sharedAppEngine].reader clearAllTagSelect];
+    
+    if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.sensorType==MAGNUSS3) {
+        
+        [[CSLRfidAppEngine sharedAppEngine].reader TAGMSK_DESC_SEL:0];
+        [[CSLRfidAppEngine sharedAppEngine].reader selectTagForInventory:TID maskPointer:0 maskLength:28 maskData:[CSLBleReader convertHexStringToData:[NSString stringWithFormat:@"%8X", MAGNUSS3]] sel_action:0];
+        [[CSLRfidAppEngine sharedAppEngine].reader TAGMSK_DESC_SEL:1];
+        [[CSLRfidAppEngine sharedAppEngine].reader selectTagForInventory:USER maskPointer:0xE0 maskLength:0 maskData:[NSData dataWithBytes:emptyByte length:sizeof(emptyByte)] sel_action:2];
+        [[CSLRfidAppEngine sharedAppEngine].reader TAGMSK_DESC_SEL:2];
+        [[CSLRfidAppEngine sharedAppEngine].reader selectTagForInventory:USER maskPointer:0xD0 maskLength:8 maskData:[NSData dataWithBytes:OCRSSI length:sizeof(OCRSSI)] sel_action:2];
+        
+    }
+    else {
+        [[CSLRfidAppEngine sharedAppEngine].reader TAGMSK_DESC_SEL:0];
+        [[CSLRfidAppEngine sharedAppEngine].reader selectTagForInventory:TID maskPointer:0 maskLength:28 maskData:[CSLBleReader convertHexStringToData:[NSString stringWithFormat:@"%8X", MAGNUSS2]] sel_action:0];
+        [[CSLRfidAppEngine sharedAppEngine].reader TAGMSK_DESC_SEL:1];
+        [[CSLRfidAppEngine sharedAppEngine].reader selectTagForInventory:USER maskPointer:0xA0 maskLength:8 maskData:[NSData dataWithBytes:OCRSSI length:sizeof(OCRSSI)] sel_action:2];
+    }
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryCycleDelay:0];
+    [[CSLRfidAppEngine sharedAppEngine].reader setInventoryConfigurations:[CSLRfidAppEngine sharedAppEngine].settings.algorithm MatchRepeats:0 tagSelect:0 disableInventory:0 tagRead:tagRead crcErrorRead:true QTMode:0 tagDelay:(tagRead ? 30 : 0) inventoryMode:(tagRead ? 0 : 1)];
+    
+    // if multibank read is enabled
+    if (tagRead) {
+        [[CSLRfidAppEngine sharedAppEngine].reader TAGACC_BANK:[CSLRfidAppEngine sharedAppEngine].settings.multibank1 acc_bank2:[CSLRfidAppEngine sharedAppEngine].settings.multibank2];
+        [[CSLRfidAppEngine sharedAppEngine].reader TAGACC_PTR:([CSLRfidAppEngine sharedAppEngine].settings.multibank2Offset << 16) + [CSLRfidAppEngine sharedAppEngine].settings.multibank1Offset];
+        [[CSLRfidAppEngine sharedAppEngine].reader TAGACC_CNT:(tagRead ? [CSLRfidAppEngine sharedAppEngine].settings.multibank1Length : 0) secondBank:(tagRead==2 ? [CSLRfidAppEngine sharedAppEngine].settings.multibank2Length : 0)];
+        [[CSLRfidAppEngine sharedAppEngine].reader TAGACC_ACCPWD:0x00000000];
+        [[CSLRfidAppEngine sharedAppEngine].reader setInventoryConfigurations:[CSLRfidAppEngine sharedAppEngine].settings.algorithm MatchRepeats:0 tagSelect:1 disableInventory:0 tagRead:tagRead crcErrorRead:true QTMode:0 tagDelay:(tagRead ? 30 : 0) inventoryMode:(tagRead ? 0 : 1)];
+        [[CSLRfidAppEngine sharedAppEngine].reader setEpcMatchConfiguration:false matchOn:false matchLength:0x00000 matchOffset:0x00000];
+    }
+    
+}
+
 
 @end

--- a/CS108iOSClient/ViewControllers/CSLTemperatureTagSettingsVC.h
+++ b/CS108iOSClient/ViewControllers/CSLTemperatureTagSettingsVC.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 #import "CSLRfidAppEngine.h"
+#import "CSLTemperatureTabVC.h"
+#import "CSLTemperatureReadVC.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,6 +23,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UITextField *txtNumberOfTemperatureAveraging;
 @property (weak, nonatomic) IBOutlet UIButton *btnSave;
 @property (weak, nonatomic) IBOutlet UISegmentedControl *scTemperatureUnit;
+@property (weak, nonatomic) IBOutlet UIButton *btnSensorType;
+@property (weak, nonatomic) IBOutlet UIButton *btnMoistureCompare;
+@property (weak, nonatomic) IBOutlet UITextField *txtMoistureValue;
+@property (weak, nonatomic) IBOutlet UIButton *btnPowerLevel;
+@property (weak, nonatomic) IBOutlet UISwitch *swDisplayTagInAscii;
+@property (weak, nonatomic) IBOutlet UIActivityIndicatorView *actSaveConfig;
 
 - (IBAction)btnSavePressed:(id)sender;
 - (IBAction)txtLowTemperatureThresholdChanged:(id)sender;
@@ -28,6 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)txtOcrssiMinChanged:(id)sender;
 - (IBAction)txtOcrssiMaxChanged:(id)sender;
 - (IBAction)txtNumberOfTemperatureAveragingChanged:(id)sender;
+- (IBAction)btnSensorTypePressed:(id)sender;
+- (IBAction)btnMoistureComparePressed:(id)sender;
+- (IBAction)btnMoistureValueChanged:(id)sender;
+- (IBAction)btnPowerLevelChanged:(id)sender;
 
 @end
 

--- a/CS108iOSClient/ViewControllers/CSLTemperatureTagSettingsVC.m
+++ b/CS108iOSClient/ViewControllers/CSLTemperatureTagSettingsVC.m
@@ -27,6 +27,19 @@
     [self.txtLowTemperatureThreshold setDelegate:self];
     [self.txtHighTemperatureThreshold setDelegate:self];
     [self.txtNumberOfTemperatureAveraging setDelegate:self];
+    [self.txtMoistureValue setDelegate:self];
+    
+    self.btnSensorType.layer.borderWidth=1.0f;
+    self.btnSensorType.layer.borderColor=[UIColor lightGrayColor].CGColor;
+    self.btnSensorType.layer.cornerRadius=5.0f;
+    
+    self.btnMoistureCompare.layer.borderWidth=1.0f;
+    self.btnMoistureCompare.layer.borderColor=[UIColor lightGrayColor].CGColor;
+    self.btnMoistureCompare.layer.cornerRadius=5.0f;
+    
+    self.btnPowerLevel.layer.borderWidth=1.0f;
+    self.btnPowerLevel.layer.borderColor=[UIColor lightGrayColor].CGColor;
+    self.btnPowerLevel.layer.cornerRadius=5.0f;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -50,6 +63,34 @@
     self.txtOcrssiMin.text=[NSString stringWithFormat:@"%d", [CSLRfidAppEngine sharedAppEngine].temperatureSettings.rssiLowerLimit];
     self.txtNumberOfTemperatureAveraging.text=[NSString stringWithFormat:@"%d", [CSLRfidAppEngine sharedAppEngine].temperatureSettings.NumberOfRollingAvergage];
     ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.unit) ? (self.scTemperatureUnit.selectedSegmentIndex = 1) : (self.scTemperatureUnit.selectedSegmentIndex = 0);
+    
+    if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.sensorType==MAGNUSS3 && [CSLRfidAppEngine sharedAppEngine].temperatureSettings.reading==TEMPERATURE)
+        [self.btnSensorType setTitle:@"Axzon Magnus S3 - Temperature" forState:UIControlStateNormal];
+    else if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.sensorType==MAGNUSS3 && [CSLRfidAppEngine sharedAppEngine].temperatureSettings.reading==MOISTURE)
+        [self.btnSensorType setTitle:@"Axzon Magnus S3 - Moisture" forState:UIControlStateNormal];
+    else
+        [self.btnSensorType setTitle:@"Axzon Magnus S2 - Moisture" forState:UIControlStateNormal];
+    
+    if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel==LOWPOWER)
+        [self.btnPowerLevel setTitle:@"Low (16dBm)" forState:UIControlStateNormal];
+    else if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel==HIGHPOWER)
+        [self.btnPowerLevel setTitle:@"High (30dBm)" forState:UIControlStateNormal];
+    else if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel==MEDIUMPOWER)
+        [self.btnPowerLevel setTitle:@"Medium (23dBm)" forState:UIControlStateNormal];
+    else
+        [self.btnPowerLevel setTitle:@"Follow System Setting" forState:UIControlStateNormal];
+    
+    if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.tagIdFormat==HEX)
+        [self.swDisplayTagInAscii setOn:false];
+    else
+        [self.swDisplayTagInAscii setOn:true];
+    
+    if ([CSLRfidAppEngine sharedAppEngine].temperatureSettings.moistureAlertCondition==GREATER)
+        [self.btnMoistureCompare setTitle:@">" forState:UIControlStateNormal];
+    else
+        [self.btnMoistureCompare setTitle:@"<" forState:UIControlStateNormal];
+    
+    [self.txtMoistureValue setText:[NSString stringWithFormat:@"%d",[CSLRfidAppEngine sharedAppEngine].temperatureSettings.moistureAlertValue]];
     
     [self.scTemperatureUnit addTarget:self action:@selector(SegmentChangeViewValueChanged:) forControlEvents:UIControlEventValueChanged];
 }
@@ -80,8 +121,33 @@
     [CSLRfidAppEngine sharedAppEngine].temperatureSettings.rssiLowerLimit=[self.txtOcrssiMin.text intValue];
     [CSLRfidAppEngine sharedAppEngine].temperatureSettings.NumberOfRollingAvergage=[self.txtNumberOfTemperatureAveraging.text intValue];
     [CSLRfidAppEngine sharedAppEngine].temperatureSettings.unit=(TEMPERATUREUNIT)self.scTemperatureUnit.selectedSegmentIndex;
+    [CSLRfidAppEngine sharedAppEngine].temperatureSettings.sensorType=[self.btnSensorType.currentTitle containsString:@"S3"] ? MAGNUSS3 : MAGNUSS2;
+    [CSLRfidAppEngine sharedAppEngine].temperatureSettings.reading=[self.btnSensorType.currentTitle containsString:@"Temperature"] ? TEMPERATURE : MOISTURE;
     
+    if ([self.btnPowerLevel.currentTitle isEqualToString:@"Low (16dBm)"])
+        [CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel=LOWPOWER;
+    else if ([self.btnPowerLevel.currentTitle isEqualToString:@"High (30dBm)"])
+        [CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel=HIGHPOWER;
+    else if ([self.btnPowerLevel.currentTitle isEqualToString:@"Medium (23dBm)"])
+        [CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel=MEDIUMPOWER;
+    else
+        [CSLRfidAppEngine sharedAppEngine].temperatureSettings.powerLevel=SYSTEMSETTING;
+    
+    [CSLRfidAppEngine sharedAppEngine].temperatureSettings.tagIdFormat=(TAGIDFORMAT)self.swDisplayTagInAscii.isOn;
+    [CSLRfidAppEngine sharedAppEngine].temperatureSettings.moistureAlertCondition=[self.btnMoistureCompare.currentTitle containsString:@">"] ? GREATER : LESSTHAN;
+    [CSLRfidAppEngine sharedAppEngine].temperatureSettings.moistureAlertValue=[self.txtMoistureValue.text intValue];
     [[CSLRfidAppEngine sharedAppEngine] saveTemperatureTagSettingsToUserDefaults];
+    
+    //refresh configurations and clear previous readings on sensor read table view
+    //[((CSLTemperatureTabVC*)self.tabBarController) setConfigurationsForTemperatureTags];
+    //initialize averaging buffer
+
+    CSLTemperatureReadVC* sensorVC = [self.tabBarController viewControllers][CSL_VC_TEMPTAB_READTEMP_VC_IDX];
+    [sensorVC.btnSelectAllTag sendActionsForControlEvents:UIControlEventTouchUpInside];
+    [sensorVC.btnRemoveAllTag sendActionsForControlEvents:UIControlEventTouchUpInside];
+    [self.actSaveConfig startAnimating];
+    [sensorVC viewWillDisappear:YES]; [sensorVC viewDidLoad]; [sensorVC viewWillAppear:YES];
+    [self.actSaveConfig stopAnimating];
     
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Settings" message:@"Settings saved." preferredStyle:UIAlertControllerStyleAlert];
     
@@ -176,6 +242,84 @@
     }
     else    //invalid input.  reset to stored configurations
         self.txtNumberOfTemperatureAveraging.text=[NSString stringWithFormat:@"%d", [CSLRfidAppEngine sharedAppEngine].temperatureSettings.NumberOfRollingAvergage];
+}
+
+- (IBAction)btnSensorTypePressed:(id)sender {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Sensor Type"
+                                                                   message:@"Please select"
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    UIAlertAction *s3Temp = [UIAlertAction actionWithTitle:@"Axzon Magnus S3 - Temperature" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                             { [self.btnSensorType setTitle:@"Axzon Magnus S3 - Temperature" forState:UIControlStateNormal]; }]; // S3 - temperature
+    UIAlertAction *s3Moist = [UIAlertAction actionWithTitle:@"Axzon Magnus S3 - Moisture" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                                  { [self.btnSensorType setTitle:@"Axzon Magnus S3 - Moisture" forState:UIControlStateNormal]; }]; // S3 - Moisture
+    UIAlertAction *s2Moist = [UIAlertAction actionWithTitle:@"Axzon Magnus S2 - Moisture" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                                { [self.btnSensorType setTitle:@"Axzon Magnus S2 - Moisture" forState:UIControlStateNormal]; }]; // S2 - Moisture
+    
+    UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]; // cancel
+    
+    [alert addAction:s3Temp];
+    [alert addAction:s3Moist];
+    [alert addAction:s2Moist];
+    [alert addAction:cancel];
+    
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (IBAction)btnMoistureComparePressed:(id)sender {
+    
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Moisture Alert"
+                                                                   message:@"Compare Condition"
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    UIAlertAction *greater = [UIAlertAction actionWithTitle:@">" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                             { [self.btnMoistureCompare setTitle:@">" forState:UIControlStateNormal]; }]; // >
+    UIAlertAction *lessThan = [UIAlertAction actionWithTitle:@"<" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                              { [self.btnMoistureCompare setTitle:@"<" forState:UIControlStateNormal]; }]; // <
+
+    
+    UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]; // cancel
+    
+    [alert addAction:greater];
+    [alert addAction:lessThan];
+    [alert addAction:cancel];
+    
+    [self presentViewController:alert animated:YES completion:nil];
+    
+}
+
+- (IBAction)btnMoistureValueChanged:(id)sender {
+    NSScanner* scan = [NSScanner scannerWithString:self.txtMoistureValue.text];
+    int val;
+    if ([scan scanInt:&val] && [scan isAtEnd] && [self.txtMoistureValue.text intValue] >= 0 && [self.txtMoistureValue.text intValue] <= 100) //valid int between 0 to 100
+    {
+        NSLog(@"Moisture alert value entered: OK");
+    }
+    else    //invalid input.  reset to stored configurations
+        self.txtMoistureValue.text=[NSString stringWithFormat:@"%d", [CSLRfidAppEngine sharedAppEngine].temperatureSettings.moistureAlertValue];
+}
+
+- (IBAction)btnPowerLevelChanged:(id)sender {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Power Level"
+                                                                   message:@"Please select"
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    UIAlertAction *sysSetting = [UIAlertAction actionWithTitle:@"Follow System Setting" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                             { [self.btnPowerLevel setTitle:@"Follow System Setting" forState:UIControlStateNormal]; }]; // Follow System Setting
+    UIAlertAction *low = [UIAlertAction actionWithTitle:@"Low (16dBm)" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                              { [self.btnPowerLevel setTitle:@"Low (16dBm)" forState:UIControlStateNormal]; }]; // Low (16dBm)
+    UIAlertAction *medium = [UIAlertAction actionWithTitle:@"Medium (23dBm)" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                              { [self.btnPowerLevel setTitle:@"Medium (23dBm)" forState:UIControlStateNormal]; }]; // Medium (23dBm)
+    UIAlertAction *high = [UIAlertAction actionWithTitle:@"High (30dBm)" style:UIAlertActionStyleDefault handler:^(UIAlertAction * action)
+                              { [self.btnPowerLevel setTitle:@"High (30dBm)" forState:UIControlStateNormal]; }]; // High (30dBm)
+    UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]; // cancel
+    
+    [alert addAction:sysSetting];
+    [alert addAction:low];
+    [alert addAction:medium];
+    [alert addAction:high];
+    [alert addAction:cancel];
+    
+    [self presentViewController:alert animated:YES completion:nil];
+    
+    
 }
 
 - (void) didInterfaceChangeConnectStatus: (CSLBleInterface *) sender {

--- a/CS108iOSClient/ViewControllers/CSLTemperatureUploadVC.h
+++ b/CS108iOSClient/ViewControllers/CSLTemperatureUploadVC.h
@@ -18,8 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UITextField *txtMQTTPublishTopic;
 @property (weak, nonatomic) IBOutlet UIButton *btnMQTTUpload;
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *actMQTTConnectIndicator;
+@property (weak, nonatomic) IBOutlet UIButton *btnSaveToFile;
 
 - (IBAction)btnMQTTUpload:(id)sender;
+- (IBAction)btnSaveToFilePressed:(id)sender;
 
 @end
 

--- a/CS108iOSClient/model/CSLRfidAppEngine.m
+++ b/CS108iOSClient/model/CSLRfidAppEngine.m
@@ -208,6 +208,18 @@ CSLRfidAppEngine * appEngine;
         temperatureSettings.NumberOfRollingAvergage = (UInt32)[defaults integerForKey:@"NumberOfRollingAvergage"];
     if([defaults objectForKey:@"temperatureUnit"])
         temperatureSettings.unit = (BOOL)[defaults boolForKey:@"temperatureUnit"];
+    if([defaults objectForKey:@"sensorType"])
+        temperatureSettings.sensorType = (SENSORTYPE)[defaults integerForKey:@"sensorType"];
+    if([defaults objectForKey:@"reading"])
+        temperatureSettings.reading = (BOOL)[defaults boolForKey:@"reading"];
+    if([defaults objectForKey:@"powerLevel"])
+        temperatureSettings.powerLevel = (POWERLEVEL)[defaults integerForKey:@"powerLevel"];
+    if([defaults objectForKey:@"tagIdFormat"])
+        temperatureSettings.tagIdFormat = (TAGIDFORMAT)[defaults boolForKey:@"tagIdFormat"];
+    if([defaults objectForKey:@"moistureAlertCondition"])
+        temperatureSettings.moistureAlertCondition = (BOOL)[defaults boolForKey:@"moistureAlertCondition"];
+    if([defaults objectForKey:@"moistureAlertValue"])
+        temperatureSettings.moistureAlertValue = (int)[defaults integerForKey:@"moistureAlertValue"];
 }
 -(void)saveTemperatureTagSettingsToUserDefaults {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -219,6 +231,12 @@ CSLRfidAppEngine * appEngine;
     [defaults setInteger:temperatureSettings.rssiUpperLimit forKey:@"rssiUpperLimit"];
     [defaults setInteger:temperatureSettings.NumberOfRollingAvergage forKey:@"NumberOfRollingAvergage"];
     [defaults setInteger:temperatureSettings.unit forKey:@"temperatureUnit"];
+    [defaults setInteger:temperatureSettings.sensorType forKey:@"sensorType"];
+    [defaults setBool:temperatureSettings.reading forKey:@"reading"];
+    [defaults setInteger:temperatureSettings.powerLevel forKey:@"powerLevel"];
+    [defaults setBool:temperatureSettings.tagIdFormat forKey:@"tagIdFormat"];
+    [defaults setBool:temperatureSettings.moistureAlertCondition forKey:@"moistureAlertCondition"];
+    [defaults setInteger:temperatureSettings.moistureAlertValue forKey:@"moistureAlertValue"];
     
     [defaults synchronize];
     

--- a/CS108iOSClient/model/CSLTemperatureTagSettings.h
+++ b/CS108iOSClient/model/CSLTemperatureTagSettings.h
@@ -11,6 +11,10 @@
 
 #define MIN_TEMP_VALUE -40.0
 #define MAX_TEMP_VALUE +85.0
+#define MIN_MOISTURE_VALUE 5
+#define MAX_MOISTURE_VALUE 490
+#define MIN_MOISTURE_VALUE_S2 0
+#define MAX_MOISTURE_VALUE_S2 31
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,13 +22,44 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(UInt32, SENSORTYPE)
 {
     MAGNUSS3 = 0xE2824030,
+    MAGNUSS2 = 0xE2824020
 };
 
 ///Temperature Unit
 typedef NS_ENUM(BOOL, TEMPERATUREUNIT)
 {
     CELCIUS = 0,
-    FAHRENHEIT=1
+    FAHRENHEIT = 1
+};
+
+///Sensor Reading
+typedef NS_ENUM(BOOL, SENSORREADING)
+{
+    TEMPERATURE = 0,
+    MOISTURE=  1
+};
+
+///Sensor Reading
+typedef NS_ENUM(BOOL, TAGIDFORMAT)
+{
+    HEX = 0,
+    ASCII=1
+};
+
+///Sensor Reading Power Level
+typedef NS_ENUM(Byte, POWERLEVEL)
+{
+    SYSTEMSETTING = 0x00,
+    LOWPOWER = 0x01,
+    MEDIUMPOWER = 0x02,
+    HIGHPOWER = 0x03
+};
+
+///Sensor Reading
+typedef NS_ENUM(BOOL, ALERTCONDITION)
+{
+    GREATER = 0,
+    LESSTHAN=1
 };
 
 @interface CSLTemperatureTagSettings : NSObject
@@ -45,6 +80,17 @@ typedef NS_ENUM(BOOL, TEMPERATUREUNIT)
 @property (assign) int NumberOfRollingAvergage;
 ///Temperature Unit being displayed
 @property (assign) TEMPERATUREUNIT unit;
+///Sensor value to be decoded (temperature/moisture)
+@property (assign) SENSORREADING reading;
+///Sensor reading power level
+@property (assign) POWERLEVEL powerLevel;
+///Tag ID display mode (HEX or ASCII)
+@property (assign) TAGIDFORMAT tagIdFormat;
+///Moisture sensing - alert condition
+@property (assign) ALERTCONDITION moistureAlertCondition;
+///Moisture sensing - alert value
+@property (assign) int moistureAlertValue;
+
 
 ///Hold a list of circular queues for each of the tag read
 @property NSMutableDictionary * temperatureAveragingBuffer;

--- a/CS108iOSClient/model/CSLTemperatureTagSettings.m
+++ b/CS108iOSClient/model/CSLTemperatureTagSettings.m
@@ -20,7 +20,12 @@
         self.rssiLowerLimit=8;
         self.rssiUpperLimit=18;
         self.sensorType=MAGNUSS3;
-        self.NumberOfRollingAvergage=5;
+        self.reading=TEMPERATURE;
+        self.powerLevel=SYSTEMSETTING;
+        self.tagIdFormat=HEX;
+        self.moistureAlertCondition=GREATER;
+        self.moistureAlertValue=100;
+        self.NumberOfRollingAvergage=3;
         self.unit=CELCIUS;
         self.temperatureAveragingBuffer = [[NSMutableDictionary alloc] init];
     }

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -112,15 +112,15 @@
 		92D48F6FBF1F30DCB32A439EA3D71571 /* MQTTClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "MQTTClient-Info.plist"; sourceTree = "<group>"; };
 		9353F3B88B485FA1DCC192F17FF59172 /* Pods-CS108iOSClient-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-CS108iOSClient-umbrella.h"; sourceTree = "<group>"; };
 		954FB9894854B019679CA0880AE720C5 /* MQTTSSLSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MQTTSSLSecurityPolicy.h; path = MQTTClient/MQTTClient/MQTTSSLSecurityPolicy.h; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A4ABA4D3978BF9C7A1D6DC32D42E312F /* MQTTTransport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MQTTTransport.m; path = MQTTClient/MQTTClient/MQTTTransport.m; sourceTree = "<group>"; };
 		A6FBFF589520AF8AF15E36D3BAFE5697 /* GCDTimer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GCDTimer.m; path = MQTTClient/MQTTClient/GCDTimer.m; sourceTree = "<group>"; };
 		A7F6A4E336D43B54549E13DDCF8E1DE9 /* Pods-CS108iOSClient-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CS108iOSClient-acknowledgements.plist"; sourceTree = "<group>"; };
 		B39F52AA4E85A6073DAA6E15A5AE021C /* Pods-CS108iOSClient.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CS108iOSClient.debug.xcconfig"; sourceTree = "<group>"; };
 		B63E165EDFA508CE62BEE6B0CFBB1B55 /* MQTTSSLSecurityPolicyDecoder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MQTTSSLSecurityPolicyDecoder.m; path = MQTTClient/MQTTClient/MQTTSSLSecurityPolicyDecoder.m; sourceTree = "<group>"; };
-		B76C34C0589F3A6AE0C8674262609FB5 /* MQTTClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = MQTTClient.framework; path = MQTTClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B76C34C0589F3A6AE0C8674262609FB5 /* MQTTClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MQTTClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B7F82341ADD4D30EC8B2857E3AE1D14B /* MQTTDecoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MQTTDecoder.h; path = MQTTClient/MQTTClient/MQTTDecoder.h; sourceTree = "<group>"; };
-		BF0975F2086ADE582F9BC7643E3AEF5F /* Pods_CS108iOSClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CS108iOSClient.framework; path = "Pods-CS108iOSClient.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF0975F2086ADE582F9BC7643E3AEF5F /* Pods_CS108iOSClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CS108iOSClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1EDEEE47F53948EF7949FEE65F0A109 /* MQTTClient.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = MQTTClient.modulemap; sourceTree = "<group>"; };
 		C90AB7C596A1BBBFC94E527A460AC38D /* Pods-CS108iOSClient-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CS108iOSClient-Info.plist"; sourceTree = "<group>"; };
 		CB4607EFCA7C5F75397649E792E2AFCB /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -243,7 +243,6 @@
 				6BD16A957F5AC2315F666DC2EE081215 /* Min */,
 				9AA573BF8BB3BDDDBAAE8DAE8F1D75F1 /* Support Files */,
 			);
-			name = MQTTClient;
 			path = MQTTClient;
 			sourceTree = "<group>";
 		};
@@ -403,14 +402,15 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
 			productRefGroup = 335388CDFB50B2940B34A78FF379E113 /* Products */;
@@ -495,6 +495,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -544,8 +545,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				SYMROOT = "${SRCROOT}/../build";
 			};
@@ -568,11 +568,7 @@
 				INFOPLIST_FILE = "Target Support Files/MQTTClient/MQTTClient-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/MQTTClient/MQTTClient.modulemap";
 				PRODUCT_MODULE_NAME = MQTTClient;
 				PRODUCT_NAME = MQTTClient;
@@ -602,11 +598,7 @@
 				INFOPLIST_FILE = "Target Support Files/MQTTClient/MQTTClient-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/MQTTClient/MQTTClient.modulemap";
 				PRODUCT_MODULE_NAME = MQTTClient;
 				PRODUCT_NAME = MQTTClient;
@@ -637,11 +629,7 @@
 				INFOPLIST_FILE = "Target Support Files/Pods-CS108iOSClient/Pods-CS108iOSClient-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-CS108iOSClient/Pods-CS108iOSClient.modulemap";
 				OTHER_LDFLAGS = "";
@@ -661,6 +649,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -738,11 +727,7 @@
 				INFOPLIST_FILE = "Target Support Files/Pods-CS108iOSClient/Pods-CS108iOSClient-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-CS108iOSClient/Pods-CS108iOSClient.modulemap";
 				OTHER_LDFLAGS = "";

--- a/Pods/Pods.xcodeproj/xcuserdata/TurtleMac01.xcuserdatad/xcschemes/MQTTClient.xcscheme
+++ b/Pods/Pods.xcodeproj/xcuserdata/TurtleMac01.xcuserdatad/xcschemes/MQTTClient.xcscheme
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES">
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4BD6D2889A94B4B433A0B09AE70BBBB2"
@@ -23,14 +23,17 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -38,17 +41,25 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4BD6D2889A94B4B433A0B09AE70BBBB2"
+            BuildableName = "MQTTClient.framework"
+            BlueprintName = "MQTTClient"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES"
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Pods/Pods.xcodeproj/xcuserdata/TurtleMac01.xcuserdatad/xcschemes/Pods-CS108iOSClient.xcscheme
+++ b/Pods/Pods.xcodeproj/xcuserdata/TurtleMac01.xcuserdatad/xcschemes/Pods-CS108iOSClient.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
- Added Azxon Magnus S2 tag support
- Tag read for temperature and moisture sensing (in terms of percentage in the scale)
- Added API calls: clearAllTagSelect, setEpcMatchConfiguration and setInventoryCycleDelay
- Reload configurations from Users Defaults before and after temperature tag read
- Added configuration parameters for moisture sensing and alerts
- Enabled saving tag data to local csv files
- Enable 3 level power settings for temperature tags
- Display tags in raw hex digits or ASCII format
- Version: 2.4