### PR TITLE
Indicate RFID MAC error

### DIFF
--- a/CS108iOSClient/CSLReader/CSLBleReader+AccessControl.m
+++ b/CS108iOSClient/CSLReader/CSLBleReader+AccessControl.m
@@ -1488,8 +1488,10 @@
         [[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(8, 4)] isEqualToString:@"0080"]) ||
         ([[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(4, 2)] isEqualToString:@"01"] &&
          [[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(8, 4)] isEqualToString:@"0000"])
-        )
+        ) {
+        self.lastMacErrorCode=0x0000;
         NSLog(@"Receive read command-begin response: OK");
+    }
     else
     {
         NSLog(@"Receive read command-begin response: FAILED");
@@ -1594,8 +1596,10 @@
              [[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(8, 4)] isEqualToString:@"0080"]) ||
             ([[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(4, 2)] isEqualToString:@"01"] &&
              [[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(8, 4)] isEqualToString:@"0000"])
-            )
+            ) {
+            self.lastMacErrorCode=0x0000;
             NSLog(@"Receive read command-begin response: OK");
+        }
         else
         {
             NSLog(@"Receive read command-begin response: FAILED");
@@ -1659,8 +1663,10 @@
          [[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(8, 4)] isEqualToString:@"0080"]) ||
         ([[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(4, 2)] isEqualToString:@"01"] &&
          [[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(8, 4)] isEqualToString:@"0000"])
-        )
+        ) {
+        self.lastMacErrorCode=0x0000;
         NSLog(@"Receive search command-begin response: OK");
+    }
     else
     {
         NSLog(@"Receive search command-begin response: FAILED");
@@ -1829,8 +1835,10 @@
          [[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(8, 4)] isEqualToString:@"0080"]) ||
         ([[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(4, 2)] isEqualToString:@"01"] &&
          [[recvPacket.getPacketPayloadInHexString substringWithRange:NSMakeRange(8, 4)] isEqualToString:@"0000"])
-        )
+        ) {
+        self.lastMacErrorCode=0x0000;
         NSLog(@"Receive read command-begin response: OK");
+    }
     else
     {
         NSLog(@"Receive read command-begin response: FAILED");

--- a/CS108iOSClient/CSLReader/CSLBleReader.h
+++ b/CS108iOSClient/CSLReader/CSLBleReader.h
@@ -128,6 +128,9 @@ Insertion/update of tag data is based on binary searching algorithm for better e
 ///Delegate instance that follows the CSLBleReaderDelegate protocol
 @property (nonatomic, weak) id <CSLBleReaderDelegate> readerDelegate;
 
+///This error will be cleared every time when a host command is being initiated and set after and command-end response
+@property unsigned short lastMacErrorCode;
+
 /**
  Static method that converts hexdcecimal string to binary data
  

--- a/CS108iOSClient/Info.plist
+++ b/CS108iOSClient/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2690</string>
+	<string>2705</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>

--- a/CS108iOSClient/ViewControllers/CSLInventoryVC.m
+++ b/CS108iOSClient/ViewControllers/CSLInventoryVC.m
@@ -126,6 +126,17 @@
             else
                 self.lbStatus.text=[NSString stringWithFormat:@"Battery: %d%%", [CSLRfidAppEngine sharedAppEngine].readerInfo.batteryPercentage];
         }
+        
+        if ([CSLRfidAppEngine sharedAppEngine].reader.lastMacErrorCode != 0x0000)
+        {
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"RFID Error"
+                                                                           message:[NSString stringWithFormat:@"Error Code: 0x%04X", [CSLRfidAppEngine sharedAppEngine].reader.lastMacErrorCode]
+                                                                    preferredStyle:UIAlertControllerStyleAlert];
+            UIAlertAction *ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+            [alert addAction:ok];
+            [self presentViewController:alert animated:YES completion:nil];
+            [CSLRfidAppEngine sharedAppEngine].reader.lastMacErrorCode=0x0000;
+        }
     }
 }
 


### PR DESCRIPTION
- Added property to the CSLBleReader class for holding the last mac error returned from the RFID module
- Display mac error on pop-up dialog when an mac error occurs.